### PR TITLE
Adds scripts used by Strap

### DIFF
--- a/script/bootstrap
+++ b/script/bootstrap
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+
+create_dns_location () {
+  location="${1}"
+  shift
+
+  if ! sudo networksetup -switchtolocation "${location}" ; then
+    sudo networksetup -createlocation "${location}" populate
+    sudo networksetup -switchtolocation "${location}" 
+    sudo networksetup -setdnsservers Wi-Fi $@
+  fi
+}
+
+if mac; then
+  create_dns_location "Home DNS" 10.13.6.253 10.13.6.254
+  create_dns_location "Google DNS" 8.8.8.8 8.8.4.4
+  create_dns_location "Cloudflare DNS" 1.1.1.1 1.0.0.1
+  create_dns_location "Quad9 DNS" 9.9.9.9 149.112.112.112
+  create_dns_location "Tailscale DNS" 100.85.25.21
+  sudo networksetup -switchtolocation "Automatic" 
+fi
+
+# install oh-my-zsh
+sh -c "$(curl -fsSL https://raw.githubusercontent.com/ohmyzsh/ohmyzsh/master/tools/install.sh)"
+
+# use my customizations to oh-my-zsh
+ZSH_CUSTOM=${HOME}/workspace/oh-my-zsh-custom
+rm -rf ${ZSH_CUSTOM} 2>/dev/null
+git clone https://github.com/crdant/oh-my-zsh-custom.git ${ZSH_CUSTOM}
+
+# setup some directories
+mkdir -p ~/sandbox
+mkdir -p ~/workspace
+mkdir -p ~/workspace/learning
+mkdir -p ~/workspace/learning/exercism
+mkdir -p ~/"Virtual Box VMs"
+
+# setup aliases I'm used to having
+Rez -append files/icons/workspace.rsrc -o ~/workspace/$'Icon\r'
+SetFile -a C ~/workspace
+
+# follow the LSB for some home-level content
+mkdir -p ~/bin
+mkdir -p ~/etc
+mkdir -p ~/share
+
+# make sure I can work with my oh my zsh and my dotfiles easily
+ln -sf ~/.dotfiles ~/workspace/dotfiles
+
+

--- a/script/strap-after-setup
+++ b/script/strap-after-setup
@@ -1,0 +1,104 @@
+#!/usr/bin/env bash
+
+# default to zsh for my user
+sudo chsh -u ${USER} -s /bin/zsh
+
+# Install useful extensions for VSCode"
+code --install-extension EditorConfig.EditorConfig
+code --install-extension esbenp.prettier-vscode
+code --install-extension file-icons.file-icons
+code --install-extension jaspernorth.vscode-pigments
+code --install-extension ms-vscode-remote.remote-containers
+code --install-extension ms-vsliveshare.vsliveshare
+code --install-extension ms-vsliveshare.vsliveshare-audio
+code --install-extension ms-vsliveshare.vsliveshare-pack
+code --install-extension coenraads.bracket-pair-colorizer-2
+code --install-extension britesnow.vscode-toggle-quotes
+code --install-extension vscodevim.vim
+code --install-extension Gruntfuggly.todo-tree
+code --install-extension ms-vscode-remote.remote-containers
+code --install-extension redhat.vscode-yaml
+code --install-extension GitHub.vscode-pull-request-github
+code --install-extension Pivotal.vscode-concourse
+
+# set up Dock
+dockutil --remove all
+dockutil --add "/Applications/iTerm.app" --after "Siri"
+dockutil --add "/Applications/Google Chrome.app" --after "iTerm"
+dockutil --add "/Applications/Slack.app" --after "Chrome"
+dockutil --add "/Applications/Superhuman.app" --after "Slack"
+dockutil --add "/System/Applications/Messages.app" --after "Airmail"
+dockutil --add "/Applications/Twitter.app" --after "Messages"
+dockutil --add "/System/Applications/Contacts.app" --after "Twitter"
+dockutil --add "/Applications/Fantastical.app" --after "Contacts"
+dockutil --add "/Applications/Todoist.app" --after "Fantastical"
+dockutil --add "/Applications/Bear.app" --after "Todoist"
+dockutil --add "/System/Applications/News.app" --after "Bear"
+dockutil --add "/System/Applications/Music.app" --after "News"
+dockutil --add "/System/Applications/TV.app" --after "Music"
+dockutil --add "/System/Applications/Books.app" --after "TV"
+dockutil --add "/System/Applications/Photos.app" --after "Books"
+dockutil --add "/Applications/Keynote.app" --after "Photos"
+dockutil --add "/Applications/Numbers.app" --after "Keynote"
+dockutil --add "/Applications/Pages.app" --after "Numbers"
+dockutil --add "/Applications/Visual Studio Code.app" --after "Pages"
+dockutil --add "/Applications/Postman.app" --after "Dash"
+dockutil --add "/System/Applications/App Store.app" --after "Postman"
+dockutil --add "/System/Applications/Utilities/Activity Monitor.app" --after "App Store"
+dockutil --add "/System/Applications/Utilities/Console.app" --after "Activity Monitor"
+dockutil --add "/System/Applications/System Preferences.app" --after "Console"
+
+# setup some directories
+mkdir -p ~/sandbox
+mkdir -p ~/workspace
+mkdir -p ~/workspace/learning
+mkdir -p ~/workspace/learning/exercism
+mkdir -p ~/"Virtual Box VMs"
+
+# setup aliases I'm used to having
+Rez -append files/icons/workspace.rsrc -o ~/workspace/$'Icon\r'
+SetFile -a C ~/workspace
+
+# follow the LSB for some home-level content
+mkdir -p ~/bin
+mkdir -p ~/etc
+mkdir -p ~/share
+
+# make sure I can work with my oh my zsh and my dotfiles easily
+ln -sf ~/.dotfiles ~/workspace/dotfiles
+
+# Common file folders and links
+mkdir -p ~/Documents/Inbox 
+ln -sf ~/Documents/Inbox ~/Desktop
+mkdir -p ~/Documents/Outbox 
+ln -sf ~/Documents/Outbox ~/Desktop
+mkdir -p ~/Documents/Archive 
+ln -sf ~/Documents/Archive ~/Desktop
+mkdir -p ~/Documents/Pending 
+ln -sf ~/Documents/Pending ~/Desktop
+mkdir -p ~/Documents/Projects 
+ln -sf ~/Documents/Projects ~/Desktop
+mkdir -p ~/Documents/Read 
+ln -sf ~/Documents/Read ~/Desktop
+mkdir -p ~/Documents/Watch 
+ln -sf ~/Documents/Watch ~/Desktop
+
+# setup login items
+loginitems -a  "Alfred 4"
+open /Applications/Alfred\ 4.app
+
+loginitems -a "Bartender 4"
+open "/Applications/Bartender 4.app"
+
+loginitems -a "Espanso"
+open /Applications/Espanso.app
+
+loginitems -a "Popclip"
+open /Applications/Popclip.app
+
+loginitems -a "Todoist"
+open /Applications/Todoist.app
+
+loginitems -a "Amphetamine"
+open /Applications/Amphetamine.app
+


### PR DESCRIPTION
TL;DR
-----

Supports bootstrapping a mac with Strap with two new scripts

Details
-------

Provides additional scripts that Strap uses to customize the
bootstrapping process

* `scripts/bootstrap` completes additonal core bootstrapping
  with directory setup, networking setup, and other things that
  can be done on a bare OS X install
* `scripts/strap-after-setup` runs setups steps that depend on
  the system being further configured by Strap, such as running
  commands installed by Homebrew to configure my machine to my
  liking
