### PR TITLE
Updates `zshrc` to use oh-my-zsh custom directory

### DIFF
--- a/zshrc
+++ b/zshrc
@@ -3,6 +3,8 @@ arch=$(uname -m)
 
 # Path to your oh-my-zsh configuration.
 ZSH=$HOME/.oh-my-zsh
+ZSH_CUSTOM=${HOME}/workspace/oh-my-zsh-custom
+fpath=(${ZSH_CUSTOM}/completions $fpath)
 
 # Set name of the theme to load.
 # Look in ~/.oh-my-zsh/themes/
@@ -32,9 +34,9 @@ COMPLETION_WAITING_DOTS="true"
 # Which plugins would you like to load? (plugins can be found in ~/.oh-my-zsh/plugins/*)
 # Custom plugins may be added to ~/.oh-my-zsh/custom/plugins/
 # Example format: plugins=(rails git textmate ruby lighthouse)
-plugins=(git git-flow gpg-agent tmux emoji docker aws minikube kubectl helm history-substring-search pasteboard velero terraform)
+plugins=(git git-flow gpg-agent tmux emoji docker aws minikube kubectl helm history-substring-search velero terraform)
 if [[ $os == "darwin" ]]; then
-  plugins+=(iterm2 brew macos)
+  plugins+=(iterm2 brew macos pasteboard)
 fi
 source $ZSH/oh-my-zsh.sh
 


### PR DESCRIPTION
TL;DR
------

Switches Oh My Zsh configuration to use a customization directory

Details
-------

Modifies my ZSH config to take advantage of a custom directory
from another repository. This allows me to move away from my fork
of Oh My Zsh that was only forked to provide a theme, a couple of
custom plugins, and some completions. This change is  tied to
changes in [my Oh My Zsh Customizatons
repo](https://github.com/crdant/oh-my-zsh-customizations) which
was the fork but is now just my customizations.
