### PR TITLE
Gets rid of stray self-link in `~/.dotfiles`

### DIFF
--- a/script/bootstrap
+++ b/script/bootstrap
@@ -77,10 +77,9 @@ mkdir -p ${HOME}/bin
 mkdir -p ${HOME}/etc
 mkdir -p ${HOME}/share
 
-# make sure I can work with my oh my zsh and my dotfiles easily
-if [ ! -L ${HOME}/workspace/dotfiles ] ; then
-  ln -sf ${HOME}/dotfiles ${HOME}/workspace/dotfiles  
-fi
+# make sure I can work with dotfiles easily
+unlink ${HOME}/workspace/dotfiles
+ln -sf ${HOME}/.dotfiles ${HOME}/workspace/dotfiles
 
 # MacOS preferences and customizations snagged from Mathias Bynensat
 # and Pivotal's workstation setup

--- a/script/strap-after-setup
+++ b/script/strap-after-setup
@@ -70,9 +70,6 @@ mkdir -p ~/bin
 mkdir -p ~/etc
 mkdir -p ~/share
 
-# make sure I can work with my oh my zsh and my dotfiles easily
-ln -sf ~/.dotfiles ~/workspace/dotfiles
-
 # Common file folders and links
 mkdir -p ~/Documents/Inbox 
 ln -sf ~/Documents/Inbox ~/Desktop


### PR DESCRIPTION
TL;DR
-----

Finally rids my setup of a self-linking symlink in `~/.dotfiles`

Details
-------

For as long as I've been automating my setup I've had some stray
symlinks which are self-links inside directories I'm trying to
set up a link to. I removed a couple of the links since they were
ones I wasn't really using, but the one at `~/.dotfiles/.dotfiles`
persisted. This change gets rid of it.
