### PR TITLE
Fixes two little nits in `strap-after-setup`

### DIFF
--- a/script/strap-after-setup
+++ b/script/strap-after-setup
@@ -1,7 +1,8 @@
 #!/usr/bin/env bash
 
 # default to zsh for my user
-sudo chsh -u ${USER} -s /bin/zsh
+MY_USER=${USER}
+sudo chsh -u ${MY_USER} -s /bin/zsh
 
 # convert color palette links to hard links so that the palettes
 # load correctly in the color picker
@@ -11,22 +12,22 @@ find ${HOME}/Library/Colors -type l -exec bash -c 'ln -f "$(greadlink -m "$0")" 
 find ${HOME}/Library/Preferences -type l -exec bash -c 'ln -f "$(greadlink -m "$0")" "$0"' {} \;1
 
 # Install useful extensions for VSCode"
-code --install-extension EditorConfig.EditorConfig
-code --install-extension esbenp.prettier-vscode
-code --install-extension file-icons.file-icons
-code --install-extension jaspernorth.vscode-pigments
-code --install-extension ms-vscode-remote.remote-containers
-code --install-extension ms-vsliveshare.vsliveshare
-code --install-extension ms-vsliveshare.vsliveshare-audio
-code --install-extension ms-vsliveshare.vsliveshare-pack
-code --install-extension coenraads.bracket-pair-colorizer-2
-code --install-extension britesnow.vscode-toggle-quotes
-code --install-extension vscodevim.vim
-code --install-extension Gruntfuggly.todo-tree
-code --install-extension ms-vscode-remote.remote-containers
-code --install-extension redhat.vscode-yaml
-code --install-extension GitHub.vscode-pull-request-github
-code --install-extension Pivotal.vscode-concourse
+code --install-extension --force EditorConfig.EditorConfig
+code --install-extension --force esbenp.prettier-vscode
+code --install-extension --force file-icons.file-icons
+code --install-extension --force jaspernorth.vscode-pigments
+code --install-extension --force ms-vscode-remote.remote-containers
+code --install-extension --force ms-vsliveshare.vsliveshare
+code --install-extension --force ms-vsliveshare.vsliveshare-audio
+code --install-extension --force ms-vsliveshare.vsliveshare-pack
+code --install-extension --force coenraads.bracket-pair-colorizer-2
+code --install-extension --force britesnow.vscode-toggle-quotes
+code --install-extension --force vscodevim.vim
+code --install-extension --force Gruntfuggly.todo-tree
+code --install-extension --force ms-vscode-remote.remote-containers
+code --install-extension --force redhat.vscode-yaml
+code --install-extension --force GitHub.vscode-pull-request-github
+code --install-extension --force Pivotal.vscode-concourse
 
 # set up Dock
 dockutil --remove all


### PR DESCRIPTION
TL;DR
-----

Corrects two bugs in `strap-after-setup` to change the right shell
and reinstall/update VS Code extensions

Details
-------

Several runs of Strap surfaced two issues with `strap-after-setup`
that needed to be fixed. This one fixes them.

* Changing my shell with `${USER}` output that it was changing
  `root`'s shell instead. I assume it was, though `/etc/passwd`
  suggests otherwise. Most likely that's a "How MacOS really
  does it" thing.
* VS Code extensions should be updated if already installed. The
  quick and dirty was to do this is to froce the install so that
  either the newest version is installed or the current version
  is reinstalled.
