### PR TITLE
Uses `python3`, `pip3`, etc. as `python`, `pip`, etc.

### DIFF
--- a/files/zsh/.zshenv
+++ b/files/zsh/.zshenv
@@ -11,7 +11,7 @@ export PATH=/usr/local/bin:${PATH}
 export PATH=/usr/local/sbin:${PATH}
 
 if [[  $arch == 'arm64' ]]; then
-  export PATH=/opt/homebrew/bin:/opt/homebrew/sbin/:${PATH}
+  export PATH=/opt/homebrew/bin:/opt/homebrew/sbin/:/opt/homebrew/opt/python@3/libexec/bin:${PATH}
 fi
 
 # linux brew on linux


### PR DESCRIPTION
TL;DR
-----

Updates path to use the Homebrew convention for the bare Python
related executables to refer to Python 3

Details
-------

Follows the convention laid out by Homebrew of adding the Python
keg into the path referencing `libexec/bin` so that the bare
executables like `python` and `pip` refernce the Python3 versions
installed by Homebrew.
