### PR TITLE
Avoids setting power related parameters

### DIFF
--- a/script/bootstrap
+++ b/script/bootstrap
@@ -125,18 +125,6 @@ sudo pmset -a lidwake 1
 # Restart automatically on power loss
 sudo pmset -a autorestart 1
 
-# Sleep the display after 5 minutes
-sudo pmset -a displaysleep 5
-
-# Disable machine sleep while charging
-sudo pmset -c sleep 0
-
-# set display sleep to 2 minutes on batter
-sudo pmset -b displaysleep 2
-
-# Set machine sleep to 5 minutes on battery
-sudo pmset -b sleep 5
-
 # Require password immediately after sleep or screen saver begins
 defaults write com.apple.screensaver askForPassword -int 1
 defaults write com.apple.screensaver askForPasswordDelay -int 0


### PR DESCRIPTION
TL;DR
-----

Removes power related settings until I can research them

Details
-------

Mac was running hot and charging slow, and the only difference
was that I'd set some power management parameters as part of
testing the `bootstrap` script. This fix removes those calls
while I research if there's a connection and what settings might
make more sense.
