### PR TITLE
Configures diff for binary property lists

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,2 @@
 *.enc diff=secrets
+*.enc diff=plist

--- a/files/git/.gitconfig
+++ b/files/git/.gitconfig
@@ -75,3 +75,5 @@
 	rebase = false
 [diff "secrets"]
 	textconv = secrets diff
+[diff "plist"]
+	textconv = plutil -p


### PR DESCRIPTION
TL;DR
-----

Configures this repository and git to diff binary property lists

Details
-------

* Updates `.gitconfig` to provide text conversion for binary
  property lists
* Configurres this respository to use the property list conversion
  for all files ending in `*.plist`
