### PR TITLE
Prevents overwrite of iTerm2 symlink

### DIFF
--- a/script/bootstrap
+++ b/script/bootstrap
@@ -214,9 +214,6 @@ defaults write com.apple.Safari SendDoNotTrackHTTPHeader -bool true
 # Update extensions automatically
 defaults write com.apple.Safari InstallExtensionUpdatesAutomatically -bool true
 
-# Don’t display the annoying prompt when quitting iTerm
-defaults write com.googlecode.iterm2 PromptOnQuit -bool false
-
 # Show the main window when launching Activity Monitor
 defaults write com.apple.ActivityMonitor OpenMainWindow -bool true
 


### PR DESCRIPTION
TL;DR
-----

Doesn't set manual properties on iTerm2

Details
-------

Avoids directly writing an iTerm2 preference so symlink isn't
overwritten before I can make it a hard link
