### PR TITLE
Fixes shell change for MacOS syntax

### DIFF
--- a/script/strap-after-setup
+++ b/script/strap-after-setup
@@ -1,8 +1,7 @@
 #!/usr/bin/env bash
 
 # default to zsh for my user
-MY_USER=${USER}
-sudo chsh -u ${MY_USER} -s /bin/zsh
+sudo chsh -s /bin/zsh ${USER}
 
 # import Github's GPG keys
 curl https://github.com/web-flow.gpg | gpg --import


### PR DESCRIPTION
TL;DR
-----

Corrects syntax error when changing shell to ZSH

Details
-------

Updates the call to `chsh` to use the correct syntax for MacOS. The
previous version was using `-u` to specify the user but on MacOS
the username is an argument rather than being specified by a flag.
