### PR TITLE
Updates launch agents for ARM homebrew

### DIFF
--- a/files/certbot/Library/LaunchAgents/io.crdant.CertBotRenewal.plist
+++ b/files/certbot/Library/LaunchAgents/io.crdant.CertBotRenewal.plist
@@ -7,14 +7,14 @@
 
     <key>ProgramArguments</key>
     <array>
-      <string>/usr/local/bin/certbot</string>
+      <string>/opt/homebrew/bin/certbot</string>
       <string>renew</string>
       <string>--config-dir</string>
-      <string>/usr/local/etc/certbot</string>
+      <string>/opt/homebrew/etc/certbot</string>
       <string>--work-dir</string>
-      <string>/usr/local/var/certbot</string>
+      <string>/opt/homebrew/var/certbot</string>
       <string>--logs-dir</string>
-      <string>/usr/local/var/certbot</string>
+      <string>/opt/homebrew/var/certbot</string>
     </array>
 
     <key>Nice</key>
@@ -36,9 +36,9 @@
     <true/>
 
     <key>StandardErrorPath</key>
-    <string>/usr/local/var/certbot/renewal.err</string>
+    <string>/opt/homebrew/var/certbot/renewal.err</string>
 
     <key>StandardOutPath</key>
-    <string>/usr/local/var/certbot/renewal.out</string>
+    <string>/opt/homebrew/var/certbot/renewal.out</string>
   </dict>
 </plist>

--- a/files/homebrew/Library/LaunchAgents/io.crdant.HomebrewUpdate.plist
+++ b/files/homebrew/Library/LaunchAgents/io.crdant.HomebrewUpdate.plist
@@ -7,7 +7,7 @@
 
     <key>ProgramArguments</key>
     <array>
-      <string>/usr/local/bin/brew</string>
+      <string>/opt/homebrew/bin/brew</string>
       <string>update</string>
     </array>
 
@@ -28,9 +28,9 @@
     <true/>
 
     <key>StandardErrorPath</key>
-    <string>/usr/local/var/homebrew/update.err</string>
+    <string>/opt/homebrew/var/homebrew/update.err</string>
 
     <key>StandardOutPath</key>
-    <string>/usr/local/var/homebrew/update.out</string>
+    <string>/opt/homebrew/var/homebrew/update.out</string>
   </dict>
 </plist>

--- a/files/homebrew/Library/LaunchAgents/io.crdant.HomebrewUpgrade.plist
+++ b/files/homebrew/Library/LaunchAgents/io.crdant.HomebrewUpgrade.plist
@@ -7,7 +7,7 @@
 
     <key>ProgramArguments</key>
     <array>
-      <string>/usr/local/bin/brew</string>
+      <string>/opt/homebrew/bin/brew</string>
       <string>upgrade</string>
     </array>
 
@@ -28,9 +28,9 @@
     <true/>
 
     <key>StandardErrorPath</key>
-    <string>/usr/local/var/homebrew/upgrade.err</string>
+    <string>/opt/homebrew/var/homebrew/upgrade.err</string>
 
     <key>StandardOutPath</key>
-    <string>/usr/local/var/homebrew/upgrade.out</string>
+    <string>/opt/homebrew/var/homebrew/upgrade.out</string>
   </dict>
 </plist>


### PR DESCRIPTION
TL;DR
-----

Makes homebrew and certbot schedule jobs work again

Details
-------

Noticed today that all three of the jobs I had scheduled as Launch
Agents were failing. A quick check revealed that they all referenced
paths under `/usr/local/` for things that live under `/opt/homebrew`
on ARM macs.

This change updates them so they'll start running again.
