### PR TITLE
Installs my SSH tunnel utility

### DIFF
--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -5,4 +5,5 @@
   replicated = pkgs.callPackage ./replicated { };
   kots = pkgs.callPackage ./kots { };
   mods = pkgs.callPackage ./mods { };
+  tunnelmanager = pkgs.callPackage ./tunnelmanager { };
 }

--- a/pkgs/tunnelmanager/default.nix
+++ b/pkgs/tunnelmanager/default.nix
@@ -1,0 +1,31 @@
+{ stdenv, lib, buildGoModule, fetchFromGitHub, installShellFiles, pkg-config }:
+
+buildGoModule rec {
+  pname = "tunnelmanager";
+  version = "0.1.0";
+
+  src = fetchFromGitHub {
+    owner = "crdant";
+    repo = "tunnelmanager";
+    rev = "main";
+    sha256 = "sha256-v36xjjkukY9EXHLp9/z/YUysMCA+NXIWr9B+37UODiQ=";
+  };
+
+  vendorHash = "sha256-eKeUhS2puz6ALb+cQKl7+DGvm9Cl+miZAHX0imf9wdg=";
+
+  nativeBuildInputs = [ installShellFiles ];
+
+  postInstall = ''
+    $out/bin/tunnelctl completion bash > tunnelctl.bash
+    $out/bin/tunnelctl completion zsh > tunnelctl.zsh
+    $out/bin/tunnelctl completion fish > tunnelctl.fish
+    installShellCompletion tunnelctl.{bash,zsh,fish}
+  '';
+
+  meta = with lib; {
+    homepage = "https://github.com/crdant/tunnelmanager";
+    description = "Simple SSH tunnel manager since I always forget the arguments";
+    mainProgram = "tunnelctl";
+    license = licenses.mit;
+  };
+}

--- a/users/crdant/home.nix
+++ b/users/crdant/home.nix
@@ -104,6 +104,7 @@ in {
         tcptraceroute
         tektoncd-cli
         terraform
+        tunnelctl
         vault
         vendir
         ytt


### PR DESCRIPTION
TL;DR
-----

Incorporates my `tunnectl` utility into my Home Manager config

Details
-------

Provides a simple package to install Tunnel Manager, which is a
Go port of my simple Python script that I created because I could
never remember how to set up an SSH tunnel as a SOCKS proxy.
