### PR TITLE
Corrects Tunnel Manager package install

### DIFF
--- a/users/crdant/home.nix
+++ b/users/crdant/home.nix
@@ -104,7 +104,7 @@ in {
         tcptraceroute
         tektoncd-cli
         terraform
-        tunnelctl
+        tunnelmanager
         vault
         vendir
         ytt


### PR DESCRIPTION
TL;DR
-----

Uses the right name to refer to the Tunnel Manager package

Details
-------

Fixes Home Manager configuration to refer to the Tunnel Manager
packages by the right name (`tunnelmanager`) vs. by the name of
it's primary command (`tunnelctl`).
