### PR TITLE
Signs git commits with my personal Yubikey PIV

### DIFF
--- a/users/crdant/home.nix
+++ b/users/crdant/home.nix
@@ -264,7 +264,7 @@ in {
       userEmail = "${gitEmail}";
 
       signing = {
-        key = "~/.ssh/id_ecdsa_sk.pub";
+        key = "~/.ssh/id_personal_9a.pub";
         signByDefault = true ;
         gpgPath = "${pkgs.openssh}/bin/ssh";
       };


### PR DESCRIPTION
TL;DR
-----

Switch from FIDO2 to PIV (may stay that way)

Details
-------

Uses the PIV key from my personal Yubikey to sign git commits,
which was the last step toward using PIV vs. FIDO2.
