### PR TITLE
Revert "Signs git commits with my personal Yubikey PIV (#36)"

### DIFF
--- a/users/crdant/home.nix
+++ b/users/crdant/home.nix
@@ -265,7 +265,7 @@ in {
       userEmail = "${gitEmail}";
 
       signing = {
-        key = "~/.ssh/id_personal_9a.pub";
+        key = "~/.ssh/id_ecdsa_sk.pub";
         signByDefault = true ;
         gpgPath = "${pkgs.openssh}/bin/ssh";
       };


### PR DESCRIPTION
TL;DR
-----

This reverts commit 5e1b86a2c139f94c068a1230277e372e9d23bdf7.

Details
-------

Reverts the change I made to use the PIV key on my personal
Yubikey for SSH and git signing. Though I'd like to move away
from GPG keys I'm still in a bit of a spot until I can use SOPS
over an agent with another type of key.
