### PR TITLE
Returns to GPG for SSH and git

### DIFF
--- a/users/crdant/home.nix
+++ b/users/crdant/home.nix
@@ -265,9 +265,8 @@ in {
       userEmail = "${gitEmail}";
 
       signing = {
-        key = "~/.ssh/id_ecdsa_sk.pub";
+        key = "0805EEDF0FEA6ACD";
         signByDefault = true ;
-        gpgPath = "${pkgs.openssh}/bin/ssh";
       };
 
       aliases = { 
@@ -331,9 +330,6 @@ in {
           };
         };
 
-        gpg = {
-          format = "ssh";
-        };
       } // lib.optionals isDarwin {
         credential = {
           helper = "osxkeychain";
@@ -597,7 +593,7 @@ in {
         plugins = [ 
           "git"
           "gh"
-          # "gpg-agent"
+          "gpg-agent"
           "tmux"
           "emoji"
           "gcloud"
@@ -609,7 +605,6 @@ in {
           "vault"
           "terraform"
           "ripgrep"
-          "ssh-agent"
           "zoxide"
           ] ++ pkgs.lib.optionals isDarwin [
             "iterm2"
@@ -676,7 +671,7 @@ in {
         export GOVC_INSECURE=true
 
         # GPG Agent as SSH agent
-        # export SSH_AUTH_SOCK=$(gpgconf --list-dirs agent-ssh-socket)
+        export SSH_AUTH_SOCK=$(gpgconf --list-dirs agent-ssh-socket)
 
         # if rancher desktop is installed use it's binaries ONLY for anything not already
         # installed system-wide


### PR DESCRIPTION
TL;DR
-----

Switches back to GPG for SSH and git signing

Details
-------

Continues unwinding the switch I'd made from GPG to SSH keys for
both SSH and git. The previous change switch from a PIV key on my
personal Yubikey to the key from my Yubikey Security Key. What
I'd intended was to go back to using GPG. This change should bring
me back to that state.
