### PR TITLE
Bumps Replicated CLI version

### DIFF
--- a/pkgs/replicated/default.nix
+++ b/pkgs/replicated/default.nix
@@ -2,7 +2,7 @@
 
 buildGoModule rec {
   pname = "replicated";
-  version = "0.68.0";
+  version = "0.71.0";
 
   src = fetchFromGitHub {
     owner = "replicatedhq";


### PR DESCRIPTION
TL;DR
-----

Updates to newer Replicated CLI version

Details
-------

Manually changes the version of the Replicated CLI package. It's
going to be tough to keep up manually, so I'll need to think about
a new strategy for the Replicated releases.
