### PR TITLE
Includes KOTS to Helm tool

### DIFF
--- a/pkgs/kots2helm/default.nix
+++ b/pkgs/kots2helm/default.nix
@@ -1,0 +1,47 @@
+{ stdenv, lib, buildGoModule, fetchFromGitHub, installShellFiles }:
+
+buildGoModule rec {
+  pname = "kots2helm";
+  version = "0.0.1";
+
+  src = fetchFromGitHub {
+    owner = "replicatedhq";
+    repo = "kots2helm";
+    rev = "v${version}";
+    sha256 = "08a1wdkn4bp784ksmc8l9hrqmagp5qj4pbjd4pwax796fbgrvd4z";
+  };
+
+  vendorHash = "sha256-oeWu84qw1PyI6R4YXGZIAGMvU7QZY+DOLzFf6qAqOCI=";
+
+  ldflags = [
+    "-X github.com/replicatedhq/kots/pkg/buildversion.version=${version}"
+    "-X github.com/replicatedhq/kots/pkg/buildversion.gitSHA=${src.rev}"
+  ];
+
+  ldflagsStr = lib.strings.concatStringsSep " " ldflags ;
+
+  # Override build phase to use make
+  buildPhase = ''
+    runHook preBuild
+    export GO111MODULE=on
+    export GOPROXY=https://proxy.golang.org,direct
+    make LDFLAGS='-ldflags "${ldflagsStr}"' all 
+    runHook postBuild
+  '';
+
+  installPhase = ''
+    runHook preInstall
+    mkdir -p $out/bin
+    cp bin/kots2helm $out/bin/kots2helm
+    runHook postInstall
+  '';
+
+  nativeBuildInputs = [ installShellFiles ];
+
+  meta = with lib; {
+    homepage = "https://github.com/replicatedhq/kots2helm";
+    description = "This is an experimental CLI that attempts to convert a KOTS application to a Helm chart.";
+    mainProgram = "kots2helm";
+  };
+
+}

--- a/users/crdant/home.nix
+++ b/users/crdant/home.nix
@@ -85,6 +85,7 @@ in {
         k0sctl
         ko
         kots
+        kots2helm
         kubeseal
         kustomize
         mods


### PR DESCRIPTION
TL;DR
-----

Builds/install `kots2helm` CLI

Details
-------

Adds the `kots2helm` CLI to my user. This is an experimental tool
from Replicated that converts KOTS releases into Helm charts. It
needs work, but provides a decent starting point.
