### PR TITLE
Corects for missing `mash` jump box SSH config

### DIFF
--- a/users/crdant/config/ssh/config.d/jumpbox
+++ b/users/crdant/config/ssh/config.d/jumpbox
@@ -1,9 +1,4 @@
-Match exec "[[ $(uname) == 'Darwin' ]]" host 172.25.0.250
-  StreamLocalBindUnlink yes
-  RemoteForward /run/user/1001/gnupg/S.gpg-agent %d/.gnupg/S.gpg-agent
-  RemoteForward /run/user/1001/gnupg/S.gpg-agent.ssh %d/.gnupg/S.gpg-agent.ssh
-
-Match exec "[[ $(uname) == 'Darwin' ]]" host jumpbox
+Match exec "[[ $(uname) == 'Darwin' ]]" host mash
   CanonicalizeHostName yes
   CanonicalDomains walrus-shark.ts.net lab.shortrib.net 
   StreamLocalBindUnlink yes
@@ -13,7 +8,7 @@ Match exec "[[ $(uname) == 'Darwin' ]]" host jumpbox
 Match exec "[[ $(uname) == 'Darwin' ]]" host fullscreen
   RemoteCommand source ~/.zshrc && fullscreen
   RequestTTY Yes
-  HostName jumpbox
+  HostName mash
   CanonicalizeHostName yes
   CanonicalDomains walrus-shark.ts.net lab.shortrib.net 
   StreamLocalBindUnlink yes
@@ -23,7 +18,7 @@ Match exec "[[ $(uname) == 'Darwin' ]]" host fullscreen
 Match exec "[[ $(uname) == 'Darwin' ]]" host window
   RemoteCommand source ~/.zshrc && window
   RequestTTY Yes
-  HostName jumpbox
+  HostName mash
   CanonicalizeHostName yes
   CanonicalDomains walrus-shark.ts.net lab.shortrib.net 
   StreamLocalBindUnlink yes


### PR DESCRIPTION
TL;DR
-----

Updates SSH config to use `mash` host as a jumpbox

Details
-------

In the big change that added configuration for a jumpbox I omitted some
SSH configuration chnages for using the `mash` host. This change
includes those configurations that enable the same SSH configurations
that I need for a jumpbox for the host `mash`. It also uses the `mash`
hostname for the TMUX-based SSH connections named `window` and
`fullscreen`.
