### PR TITLE
Improves (Neo)vim and tmux Ergonomics

### DIFF
--- a/pkgs/vimr/default.nix
+++ b/pkgs/vimr/default.nix
@@ -3,11 +3,11 @@
 stdenv.mkDerivation rec {
   pname = "vimr";
   version = "v0.46.1";
-  build = "20240114.181346";
+  build = "20240426.143700"; 
 
   src = fetchurl {
     url = "https://github.com/qvacua/vimr/releases/download/${version}-${build}/VimR-v0.46.1.tar.bz2";
-    sha256 = "33aabbe736045f9901e89cef3fde7d8a758f39efca039ba7873c7961b79ee53a";
+    sha256 = "1g8l8j4grrnk8rvrp0a2d3724nz9hw6af09ij940frdr8bwvl2b9";
   };
 
   dontFixup = true;

--- a/users/crdant/home.nix
+++ b/users/crdant/home.nix
@@ -358,6 +358,7 @@ in {
       vimAlias = true;
 
       plugins = with pkgs.vimPlugins; [
+        conflict-marker-vim
         copilot-vim
         editorconfig-nvim
         {

--- a/users/crdant/home.nix
+++ b/users/crdant/home.nix
@@ -481,7 +481,7 @@ in {
         )
 
         -- Appearance
-        if vim.fn.has('g:gui_vimr') == 1 then
+        if vim.fn.has('gui_running') == 1 then
           vim.opt.background = "light"
         end
 

--- a/users/crdant/home.nix
+++ b/users/crdant/home.nix
@@ -495,6 +495,33 @@ in {
           end
         })
 
+        -- Lua-based configuration for Neovim
+
+        -- Ensure Makefiles use tabs
+        vim.api.nvim_create_autocmd("FileType", {
+          pattern = "make",
+          callback = function()
+            vim.opt_local.expandtab = false
+          end
+        })
+
+        -- Set larger indents for Go files
+        vim.api.nvim_create_autocmd("FileType", {
+          pattern = "go",
+          callback = function()
+            vim.opt_local.shiftwidth = 8
+            vim.opt_local.tabstop = 8
+          end
+        })
+
+        -- Auto format Go files on save
+        vim.api.nvim_create_autocmd("BufWritePre", {
+          pattern = "*.go",
+          callback = function()
+            vim.cmd('silent! !go fmt %')
+          end
+        })
+
         -- line numbers
         -- set relativenumber
         vim.opt.number = true

--- a/users/crdant/home.nix
+++ b/users/crdant/home.nix
@@ -362,13 +362,20 @@ in {
         copilot-vim
         editorconfig-nvim
         {
+          plugin = fzf-vim;
+          config = ''
+            " Initialize configuration dictionary
+            let g:fzf_vim = {}
+            let g:fzf_vim.preview_window = []
+          ''; 
+        }
+        {
           plugin = NeoSolarized;
           config = "colorscheme NeoSolarized";
         }
         lsp-zero-nvim
         mason-lspconfig-nvim
         mason-nvim
-        nvim-fzf
         nvim-surround
         vim-commentary
         vim-repeat

--- a/users/crdant/home.nix
+++ b/users/crdant/home.nix
@@ -406,7 +406,7 @@ in {
         -- :help smarttab
         vim.opt.smarttab = true
 
-        -- 1 tab == 4 spaces
+        -- 1 tab == 2 spaces
         vim.opt.shiftwidth = 2
         vim.opt.tabstop = 2
         vim.opt.softtabstop = 2

--- a/users/crdant/home.nix
+++ b/users/crdant/home.nix
@@ -506,6 +506,34 @@ in {
             lsp_zero.default_setup,
           },
         })
+
+        -- edits an Instruqt track in a multiple splits
+        function ChallengeEdit(args)
+          local dir = args.args
+
+          -- open the assignment 
+          vim.cmd('tabnew ' .. dir .. '/check-shell')
+
+          -- create a vertical split with the check script, which
+          -- will end up at the bottom
+          vim.cmd('vnew ' .. dir .. '/assignment.md')
+
+          -- Create two horizontal splits with the remaining files on
+          -- right hand side
+
+          vim.cmd('wincmd l')
+          vim.cmd('new ' .. dir .. '/solve-shell')
+          vim.cmd('new ' .. dir .. '/setup-shell')
+        end
+
+        local function challenge_completion(ArgLead, CmdLine, CursorPos)
+          return vim.fn.getcompletion(ArgLead, 'dir')
+        end
+
+        vim.api.nvim_create_user_command('ChallengeEdit', ChallengeEdit, {
+          nargs = 1,
+          complete = challenge_completion
+        })
       '';
     };
 

--- a/users/crdant/home.nix
+++ b/users/crdant/home.nix
@@ -516,6 +516,7 @@ in {
 
       plugins = [
         pkgs.tmuxPlugins.yank
+        pkgs.tmuxPlugins.vim-tmux-navigator 
       ];
 
       extraConfig = ''

--- a/users/crdant/home.nix
+++ b/users/crdant/home.nix
@@ -384,6 +384,7 @@ in {
       ];
 
       extraLuaConfig = ''
+
         -- General
         vim.opt.encoding = "utf-8"          -- The encoding displayed
         vim.opt.fileencoding = "utf-8"      -- The encoding written to file
@@ -484,6 +485,15 @@ in {
         if vim.fn.has('gui_running') == 1 then
           vim.opt.background = "light"
         end
+
+        -- markdown should have spell check and word wrap
+        vim.api.nvim_create_autocmd("FileType", {
+          pattern = "markdown",
+          callback = function()
+            vim.opt_local.textwidth = 78
+            vim.opt_local.spell = true
+          end
+        })
 
         -- line numbers
         -- set relativenumber


### PR DESCRIPTION
TL;DR
-----

Makes working with (Neo)vim and tmux nicer

Details
-------

This change started as a simple one: add smooth navigation between Neovim
windows and tmux panes. In addition to configuring those changes, it also
makes vim a bit nicer to work with and bumps the version of VimR. 

Notable changes:

* Adds conflict marker navigation
* Switches fzf plugins
* Corrects mis-leading comment
* Fixes logic for using light background with VimR
* Adds clever little Instruqt editing command
* Adds spelling and text width defaults for working with Markdown files
* Uses tabs in Makefiles
* Formats go files more appropriately
