### PR TITLE
Switches to correct `surround.vim`

### DIFF
--- a/users/crdant/home.nix
+++ b/users/crdant/home.nix
@@ -377,7 +377,7 @@ in {
         lsp-zero-nvim
         mason-lspconfig-nvim
         mason-nvim
-        nvim-surround
+        vim-surround
         vim-commentary
         vim-repeat
         vim-tmux-navigator


### PR DESCRIPTION
TL;DR
-----

Uses Tim Pope's `surround.vim`

Details
-------

Somehow along the way I ended up using the wrong package for what I
thought was Tim Pope's `surround.vim`, but it wasn't. I figured this out
by trying to start actively using the plugin and none of the actions
working. This fix swaps to the right plugin.
