### PR TITLE
Adds Lima

### DIFF
--- a/hosts/darwin.nix
+++ b/hosts/darwin.nix
@@ -27,6 +27,7 @@
       duti
       iterm2
       karabiner-elements
+      lima
       m-cli
       mas
       raycast


### PR DESCRIPTION
TL;DR
-----

Installs Lima on Darwin

Details
-------

Installs Lima for Linux VMs on Darwin. I've seen a few vendors using it
lately and it's used by Melange on Macs, so I thought I'd get going with
Lima.
