### PR TITLE
Adds `imgpkg` from Carvel

### DIFF
--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -12,4 +12,6 @@
 
   instruqt = pkgs.callPackage ./instruqt { };
   mods = pkgs.callPackage ./mods { };
+
+  imgpkg = pkgs.callPackage ./imgpkg { };
 }

--- a/pkgs/imgpkg/default.nix
+++ b/pkgs/imgpkg/default.nix
@@ -1,0 +1,37 @@
+{ lib, buildGoModule, fetchFromGitHub, installShellFiles }:
+
+buildGoModule rec {
+  pname = "imgpkg";
+  version = "0.42.2";
+
+  src = fetchFromGitHub {
+    owner = "carvel-dev";
+    repo = "imgpkg";
+    rev = "v${version}";
+    sha256 = "sha256-YpMAlFmSSXQYgPpkc9diIyAdJcglU66841tBDHE5VSQ=";
+  };
+
+  vendorHash = null;
+
+  nativeBuildInputs = [ installShellFiles ];
+
+  ldflags = [
+    "-X github.com/carvel-dev/imgpkg/pkg/imgpkg/cmd/version.Version=${version}"
+  ];
+
+  subPackages = [ "cmd/imgpkg" ];
+
+  postInstall = ''
+    installShellCompletion --cmd imgpkg \
+      --bash <($out/bin/imgpkg completion bash) \
+      --fish <($out/bin/imgpkg completion fish) \
+      --zsh <($out/bin/imgpkg completion zsh)
+  '';
+
+  meta = with lib; {
+    description = "Store application configuration files in Docker/OCI registries";
+    mainProgram = "imgpkg";
+    homepage = "https://carvel.dev/imgpkg";
+    license = licenses.asl20;
+  };
+}

--- a/users/crdant/home.nix
+++ b/users/crdant/home.nix
@@ -79,6 +79,7 @@ in {
       google-cloud-sdk
       govc
       helmfile
+      imgpkg
       istioctl
       krew
       kubectl


### PR DESCRIPTION
TL;DR
-----

Installs the `imgpkg` CLI from Carvel

Details
-------

Adds the `imgpkg` CLI as part of my Home Manager configuration. I'd
previously installed via Homebrew, then commented out. I don't really
recall why other than I didn't have much need for it.
