### PR TITLE
Adds a brew for `llm`

### DIFF
--- a/hosts/darwin.nix
+++ b/hosts/darwin.nix
@@ -46,7 +46,12 @@
       upgrade = true;
     };
     
+    brews = [
+      "llm"
+    ];
+
     taps = [
+
       "homebrew/bundle"
       "homebrew/cask-drivers"
       "homebrew/cask-fonts"


### PR DESCRIPTION
TL;DR
-----

Usess Homebrew to install the `llm` CLI

Details
-------

I was trying to install the `llm` CLI using Nix, which (properly) does
not allow installing plugins with the tool. I got a good way toward
setting up plugins and installing them using the mechanism it provides,
but it's pretty difficult with the way Nix install Python modules.

This change acknowledges that I needed to move on and start working with
the tool instead of playing with getting a strong, repetable install. It
installs `llm` with Homebrew with allows/requires installing the plugins
with the command itself.
