### PR TITLE
Upgrades iTerm and adds AI

### DIFF
--- a/overlays/default.nix
+++ b/overlays/default.nix
@@ -8,12 +8,12 @@
   # https://nixos.wiki/wiki/Overlays
   modifications = final: prev: {
     iterm2 = prev.iterm2.overrideAttrs (oldAttrs: let
-      newVersion = "3.5.2";
+      newVersion = "3.5.3";
       in {
         version = newVersion;
         src = prev.fetchzip {
           url = "https://iterm2.com/downloads/stable/iTerm2-${prev.lib.replaceStrings ["."] ["_"] newVersion}.zip";
-          hash = "sha256-WiRRxklI3A/3MtJY63jAkUVe8qa5jfRACzUESfwAmmw=";
+          hash = "sha256-uznoyXA3oGad88yZoVBJfLKMu8jK2PAKqwkpLq9fNzM=";
         };
       }
     );

--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -14,4 +14,7 @@
   mods = pkgs.callPackage ./mods { };
 
   imgpkg = pkgs.callPackage ./imgpkg { };
+
+  iterm-ai = pkgs.callPackage ./iterm-ai { };
+
 }

--- a/pkgs/iterm-ai/default.nix
+++ b/pkgs/iterm-ai/default.nix
@@ -1,0 +1,27 @@
+{ fetchzip, lib, stdenv }:
+
+stdenv.mkDerivation rec {
+  pname = "iterm-ai";
+  version = "1.1";
+
+  src = fetchzip {
+    url = "https://iterm2.com/downloads/ai-plugin/iTermAI-${version}.zip";
+    sha256 = "sha256-CLYnXRavvT526UTd0P+lFEQQmdtD6c+A13aX7fYWgjE=";
+  };
+
+  dontFixup = true;
+
+  installPhase = ''
+    runHook preInstall
+    APP_DIR="$out/Applications/iTermAI.app"
+    mkdir -p "$APP_DIR"
+    cp -r . "$APP_DIR"
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "An optiontional component to enable generative AI features in iTerm2";
+    homepage = "https://iterm2.com/ai-plugin.html";
+    platforms = [ "aarch64-darwin" ];
+  };
+}

--- a/users/crdant/home.nix
+++ b/users/crdant/home.nix
@@ -127,6 +127,7 @@ in {
       # minikube
       postman
       vimr
+      iterm-ai
       (callPackage ./vimr-wrapper.nix { inherit config ; })
       # vscode
     ] ++ lib.optionals isLinux [


### PR DESCRIPTION
TL;DR
-----

Bumps iTerm to 3.5.3 and install AI plugin

Details
-------

This change bumps the version of iTerm2 that's installed with my overlay
to 3.5.3. It also creates a new package `iterm-ai` that installs the AI
plugin and installs it as part of my user setup.
