### PR TITLE
Bumps Replicated KOTS CLI to 1.112.1

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -8,11 +8,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1713783779,
-        "narHash": "sha256-LTyVs3VtboaHU4cthfm2pA+SGJqgLag1q+Crxy5IooQ=",
+        "lastModified": 1716464653,
+        "narHash": "sha256-7ABtcvZf8P2axZNVV3m9LiKy1VW0lumu60sSuUOYG0o=",
         "owner": "1Password",
         "repo": "shell-plugins",
-        "rev": "bd3f3edc2cc235e77a8163451c23d9c87e0045d2",
+        "rev": "d36189bf486ff2c4d9275c9ce29ec1aa92eaa4a7",
         "type": "github"
       },
       "original": {
@@ -28,11 +28,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1713543876,
-        "narHash": "sha256-olEWxacm1xZhAtpq+ZkEyQgR4zgfE7ddpNtZNvubi3g=",
+        "lastModified": 1721719500,
+        "narHash": "sha256-nnkqjv4Y37Hydjh6HE9wW4kSkV5Q7q4iIXlL5lwUFOw=",
         "owner": "lnl7",
         "repo": "nix-darwin",
-        "rev": "9e7c20ffd056e406ddd0276ee9d89f09c5e5f4ed",
+        "rev": "884f3fe6d9bf056ba0017c132c39c1f0d07d4fec",
         "type": "github"
       },
       "original": {
@@ -66,11 +66,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1717527182,
-        "narHash": "sha256-vWSkg6AMok1UUQiSYVdGMOXKD2cDFnajITiSi0Zjd1A=",
+        "lastModified": 1720042825,
+        "narHash": "sha256-A0vrUB6x82/jvf17qPCpxaM+ulJnD8YZwH9Ci0BsAzE=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "845a5c4c073f74105022533907703441e0464bc3",
+        "rev": "e1391fb22e18a36f57e6999c7a9f966dc80ac073",
         "type": "github"
       },
       "original": {
@@ -82,11 +82,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1717362802,
-        "narHash": "sha256-E2fIxlfUVjxJM+Rm7Y9c0xQjpzbCTTGgvViHy3tF7N8=",
+        "lastModified": 1721662280,
+        "narHash": "sha256-veJoWy9VCxWaBeLYUD0BqTu2fqMvDg98TxSFau7ewaA=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "4e08cafd686c7b2a191a82e593762c3a095f88eb",
+        "rev": "ea73e7ae9dea53d112cb08fb78f4e00d1f686c54",
         "type": "github"
       },
       "original": {
@@ -98,11 +98,11 @@
     },
     "nixpkgs-unstable": {
       "locked": {
-        "lastModified": 1713805509,
-        "narHash": "sha256-YgSEan4CcrjivCNO5ZNzhg7/8ViLkZ4CB/GrGBVSudo=",
+        "lastModified": 1721622093,
+        "narHash": "sha256-iQ+quy3A1EKeFyLyAtjhgSvZHH7r+xybXZkxMhasN4I=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "1e1dc66fe68972a76679644a5577828b6a7e8be4",
+        "rev": "453402b94f39f968a7c27df28e060f69e4a50c3b",
         "type": "github"
       },
       "original": {

--- a/pkgs/kots/default.nix
+++ b/pkgs/kots/default.nix
@@ -1,17 +1,17 @@
-{ stdenv, lib, buildGoModule, fetchFromGitHub, installShellFiles, pkg-config, bash }:
+{ stdenv, lib, pkgs, buildGoModule, fetchFromGitHub, installShellFiles, pkg-config, bash }:
 
 buildGoModule rec {
   pname = "kots";
-  version = "1.109.13";
+  version = "1.112.1";
 
   src = fetchFromGitHub {
     owner = "replicatedhq";
     repo = "kots";
     rev = "v${version}";
-    sha256 = "sha256-wmJiCikyt/rfIlkreKo64KJcpJUga82GSBTsYd9+0SM=";
+    sha256 = "sha256-Mv/M+VDiKOXU2S1YqWTqJrXwL+yDIJbzklNBfnCeVJg=";
   };
 
-  vendorHash = "sha256-hb2GoDwTGKpDJ80OCYjIkCjMQw4aRxSbO4etLDqlLzM="; 
+  vendorHash = "sha256-I3x6yVycRs5qe0FcV7L5piXM9JyqYYl3keXoKKGp0Zo="; 
 
   subPackages = [ "cmd/kots/" ];
 

--- a/users/crdant/home.nix
+++ b/users/crdant/home.nix
@@ -68,7 +68,8 @@ in {
     packages = with pkgs; [
       argocd
       azure-cli
-      unstable.certbot-full
+      certbot-full
+      # unstable.certbot-full
       cloudflared
       conftest
       cosign
@@ -95,7 +96,7 @@ in {
       minio-client
       nix-prefetch-git
       nodejs_22
-      open-policy-agent
+      unstable.open-policy-agent
       oras
       packer
       rar


### PR DESCRIPTION
TL;DR
-----

Upgrades KOTS

Details
-------

Switches to the newest version of the KOTS CLI, which also required a
few other changes since they moved to a new minimum go version.

1. Updated Flake
2. Changed from the untable version of `certbot-full` to the released one
3. Moved to the unstable version of `open-policy-agent`
