### PR TITLE
Installs Git Large File Storage (`git-lfs`)

### DIFF
--- a/users/crdant/home.nix
+++ b/users/crdant/home.nix
@@ -77,6 +77,7 @@ in {
       cue
       exercism
       gh
+      git-lfs
       google-cloud-sdk
       govc
       helmfile


### PR DESCRIPTION
TL;DR
-----

Adds `git-lfs` package to user packages

Details
-------

I needed to use the `git-lfs` command with the `llm-mlc` plugin for the
`llm` CLI, so this change installs it for me.
