### PR TITLE
Update flake and bumps some version

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -28,11 +28,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1721719500,
-        "narHash": "sha256-nnkqjv4Y37Hydjh6HE9wW4kSkV5Q7q4iIXlL5lwUFOw=",
+        "lastModified": 1722609272,
+        "narHash": "sha256-Kkb+ULEHVmk07AX+OhwyofFxBDpw+2WvsXguUS2m6e4=",
         "owner": "lnl7",
         "repo": "nix-darwin",
-        "rev": "884f3fe6d9bf056ba0017c132c39c1f0d07d4fec",
+        "rev": "f7142b8024d6b70c66fd646e1d099d3aa5bfec49",
         "type": "github"
       },
       "original": {
@@ -82,11 +82,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1721662280,
-        "narHash": "sha256-veJoWy9VCxWaBeLYUD0BqTu2fqMvDg98TxSFau7ewaA=",
+        "lastModified": 1722745994,
+        "narHash": "sha256-sUc8Lt5OSWxPrAAoKClDcTMIEUBdfQy8mCQly/rwklU=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "ea73e7ae9dea53d112cb08fb78f4e00d1f686c54",
+        "rev": "66b9199d4da7edfbc31989df4f7b2b94838b52fb",
         "type": "github"
       },
       "original": {
@@ -98,11 +98,11 @@
     },
     "nixpkgs-unstable": {
       "locked": {
-        "lastModified": 1721622093,
-        "narHash": "sha256-iQ+quy3A1EKeFyLyAtjhgSvZHH7r+xybXZkxMhasN4I=",
+        "lastModified": 1722730825,
+        "narHash": "sha256-X6U+w8qFBuGPCYrZzc9mpN34aRjQ8604MonpBUkj908=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "453402b94f39f968a7c27df28e060f69e4a50c3b",
+        "rev": "f3834de3782b82bfc666abf664f946d0e7d1f116",
         "type": "github"
       },
       "original": {

--- a/pkgs/kots/default.nix
+++ b/pkgs/kots/default.nix
@@ -2,16 +2,16 @@
 
 buildGoModule rec {
   pname = "kots";
-  version = "1.112.1";
+  version = "1.112.4";
 
   src = fetchFromGitHub {
     owner = "replicatedhq";
     repo = "kots";
     rev = "v${version}";
-    sha256 = "sha256-Mv/M+VDiKOXU2S1YqWTqJrXwL+yDIJbzklNBfnCeVJg=";
+    sha256 = "sha256-MX8HUnlPJ+gocB5jZ5D3QraPb5UwFU0PPY2bOyjufdQ=";
   };
 
-  vendorHash = "sha256-I3x6yVycRs5qe0FcV7L5piXM9JyqYYl3keXoKKGp0Zo="; 
+  vendorHash = "sha256-tcPdzicrtWGXDsELKF3Bd+/pTVYP2uuYAE0Vj5Ujil8="; 
 
   subPackages = [ "cmd/kots/" ];
 

--- a/pkgs/mods/default.nix
+++ b/pkgs/mods/default.nix
@@ -2,16 +2,16 @@
 
 buildGoModule rec {
   pname = "mods";
-  version = "1.2.2";
+  version = "1.5.0";
 
   src = fetchFromGitHub {
     owner = "charmbracelet";
     repo = "mods";
     rev = "v${version}";
-    sha256 = "sha256-ecmfWnrd9gwIEGAOIcOeUnfmkKmq9dLxpKqAHJemhvU=";
+    sha256 = "sha256-Niap2qsIJwlDRITkPD2Z7NCiJubkyy8/pvagj5Beq84=";
   };
 
-  vendorHash = "sha256-pJ31Lsa5VVix3BM4RrllQA3MJ/JeNIKfQ8RClyFfXCI=";
+  vendorHash = "sha256-DaSbmu1P/umOAhG901aC+TKa3xXSvUbpYsaiYTr2RJs=";
 
   # nativeBuildInputs = [ installShellFiles pkg-config ];
 

--- a/pkgs/replicated/default.nix
+++ b/pkgs/replicated/default.nix
@@ -2,13 +2,13 @@
 
 buildGoModule rec {
   pname = "replicated";
-  version = "0.78.0";
+  version = "0.79.0";
 
   src = fetchFromGitHub {
     owner = "replicatedhq";
     repo = "replicated";
     rev = "v${version}";
-    sha256 = "sha256-bY4QA9QzJ2YDSbWMVEbb/RxvSRdDpUT2jViP3LqNLHI=";
+    sha256 = "sha256-pwM4Yro0xtCvK0RaDc5KU+TlUU0uBmjG3f7LTDF6lYM=";
   };
 
   vendorHash = "sha256-ek/Y2StC5QiUY81SQENArP9YN5I+afEHGplHARCcZos=";


### PR DESCRIPTION
TL;DR
-----

Refreshes flake and bumps version for own packages

Details
-------

Keeps things fresh:

* Updates flake
* Bumps to KOTS 1.112.4
* Bumps Replicated to 0.79.0
* Catches up to VimR release
* Catches up with `mods` CLI release
