### PR TITLE
Updates version of iTerm2

### DIFF
--- a/overlays/default.nix
+++ b/overlays/default.nix
@@ -18,12 +18,12 @@
       }
     );
     iterm2 = prev.iterm2.overrideAttrs (oldAttrs: let
-      newVersion = "3.5.5";
+      newVersion = "3.5.6";
       in {
         version = newVersion;
         src = prev.fetchzip {
           url = "https://iterm2.com/downloads/stable/iTerm2-${prev.lib.replaceStrings ["."] ["_"] newVersion}.zip";
-          hash = "sha256-ehx95O4Xkv1zVkdbQ/JFaXMEggQeKa4mETYDQrjXOn4=";
+          hash = "sha256-UUrbaIdk3kQNHvqJEdBtAI943qCYAoPwKjDQx3TTPFA=";
         };
       }
     );


### PR DESCRIPTION
TL;DR
-----

Bumps iTerm2 to version 3.5.6

Details
-------

Moves to iTerm2 3.5.6 in the overlay that keeps me more current than the
Nix pacakges version.
