### PR TITLE
Moves the Nix Store to its own disk

### DIFF
--- a/hosts/mash/hardware-configuration.nix
+++ b/hosts/mash/hardware-configuration.nix
@@ -26,6 +26,11 @@
       fsType = "ext4";
     };
 
+  fileSystems."/nix" =
+    { device = "/dev/disk/by-uuid/fec52b01-effb-4616-bed8-a7502c967406";
+      fsType = "ext4";
+    };
+
   swapDevices =
     [ { device = "/dev/disk/by-uuid/e12ad2b7-69b9-402d-94a4-4e382d0d2c7d"; }
     ];


### PR DESCRIPTION
TL;DR
-----

Splits Nix Store and root to their own disks

Details
-------

Disk space was becoming a problem with the regular Nix updates, an that
was leading to issues with a full root disk. This change reconfigures
Nix to use a second disk for the store to protect the root disk and
manage the space independently.
