### PR TITLE
feature/crdant/installs ghostty on darwin

### DIFF
--- a/hosts/darwin.nix
+++ b/hosts/darwin.nix
@@ -47,11 +47,11 @@
     };
     
     brews = [
+      "ghostty"
       "llm"
     ];
 
     taps = [
-
       "homebrew/bundle"
       "homebrew/cask-drivers"
       "homebrew/cask-fonts"

--- a/users/crdant/config/ghostty/config
+++ b/users/crdant/config/ghostty/config
@@ -1,0 +1,3 @@
+theme = dark:rose-pine-moon,light:rose-pine-dawn
+font-family = "Inconsolata Regular Regular"
+font-size = 11

--- a/users/crdant/home.nix
+++ b/users/crdant/home.nix
@@ -391,6 +391,7 @@ in {
           plugin = rose-pine;
           config = ''
             let g:rose_pine_dark_variant = 'moon'
+            let g:rose_pine_disable_background = 1 
             colorscheme rose-pine
           '';
         }
@@ -603,6 +604,7 @@ in {
       enable = true ;
       keyMode = "vi" ;
       sensibleOnTop = true ;
+      terminal = "tmux-256color";
 
       plugins = [
         pkgs.tmuxPlugins.rose-pine

--- a/users/crdant/home.nix
+++ b/users/crdant/home.nix
@@ -604,7 +604,7 @@ in {
       enable = true ;
       keyMode = "vi" ;
       sensibleOnTop = true ;
-      terminal = "tmux-256color";
+      terminal = "tmux-256color" ;
 
       plugins = [
         pkgs.tmuxPlugins.rose-pine

--- a/users/crdant/home.nix
+++ b/users/crdant/home.nix
@@ -885,6 +885,9 @@ in {
       "karabiner/karabiner.json" = {
         text = builtins.readFile ./config/karabiner/karabiner.json ;
       };
+      "ghostty/config" = {
+        source = ./config/ghostty/config;
+      };
     } // lib.optionalAttrs isLinux { 
       "glow/glow.yml" = {
         text = builtins.readFile ./config/glow/glow.yml ;


### PR DESCRIPTION
TL;DR
-----

Installs Ghostty on MacOS with Homebrew

Details
-------

Starts my journey trying out Ghostty on my Macs by installing it to
Darwin hosts using Homebrew.