### PR TITLE
Installs iTerm2 v. 3.5.11

### DIFF
--- a/overlays/default.nix
+++ b/overlays/default.nix
@@ -18,12 +18,12 @@
       }
     );
     iterm2 = prev.iterm2.overrideAttrs (oldAttrs: let
-      newVersion = "3.5.10";
+      newVersion = "3.5.11";
       in {
         version = newVersion;
         src = prev.fetchzip {
           url = "https://iterm2.com/downloads/stable/iTerm2-${prev.lib.replaceStrings ["."] ["_"] newVersion}.zip";
-          hash = "sha256-tvHAuHitB5Du8hqaBXmWzplrmaLF6QxV8SNsRyfCUfM=";
+          hash = "sha256-vcZL74U9RNjhpIQRUUn6WueYhE/LfLqpb/JgWunY5dI=";
         };
       }
     );


### PR DESCRIPTION
TL;DR
-----

Bumps iTerm2 to v. 3.5.11 to patch a security issue

Details
-------

Updates iTerm2 overlay for the current latest version. This fixes a
security issue.
