### PR TITLE
Freshens up flakes and versions

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -8,11 +8,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1733392675,
-        "narHash": "sha256-bHffNRWzOSdyLEiOi+zf9o10cN6/olP9T5UxKHgxoJ0=",
+        "lastModified": 1736867504,
+        "narHash": "sha256-rAIwer/Pd6nY4+9dnSd5iBKiyCP8NtjIX9Vzv3nGPxQ=",
         "owner": "1Password",
         "repo": "shell-plugins",
-        "rev": "f03bbc885daf60554ed7b0d011efe0f3e1e48c7e",
+        "rev": "6e74fd81477dcf0acaff7afaa919183ee56a7416",
         "type": "github"
       },
       "original": {
@@ -28,15 +28,16 @@
         ]
       },
       "locked": {
-        "lastModified": 1735218083,
-        "narHash": "sha256-MoUAbmXz9TEr7zlKDRO56DBJHe30+7B5X7nhXm+Vpc8=",
+        "lastModified": 1739302249,
+        "narHash": "sha256-C2vkThXQfsV7Ub0NP+rmm0iLLNjN9MvDjrbeZw2ZxCQ=",
         "owner": "lnl7",
         "repo": "nix-darwin",
-        "rev": "bc03f7818771a75716966ce8c23110b715eff2aa",
+        "rev": "f81c16138a6d047dcd257952688114898f5f7878",
         "type": "github"
       },
       "original": {
         "owner": "lnl7",
+        "ref": "nix-darwin-24.11",
         "repo": "nix-darwin",
         "type": "github"
       }
@@ -66,43 +67,43 @@
         ]
       },
       "locked": {
-        "lastModified": 1726989464,
-        "narHash": "sha256-Vl+WVTJwutXkimwGprnEtXc/s/s8sMuXzqXaspIGlwM=",
+        "lastModified": 1736373539,
+        "narHash": "sha256-dinzAqCjenWDxuy+MqUQq0I4zUSfaCvN9rzuCmgMZJY=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "2f23fa308a7c067e52dfcc30a0758f47043ec176",
+        "rev": "bd65bc3cde04c16755955630b344bc9e35272c56",
         "type": "github"
       },
       "original": {
         "owner": "nix-community",
-        "ref": "release-24.05",
+        "ref": "release-24.11",
         "repo": "home-manager",
         "type": "github"
       }
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1735125233,
-        "narHash": "sha256-YJwQfdSFep6IFrhZGEjug/HuCauGntDAesjCS5mxTis=",
+        "lastModified": 1739151041,
+        "narHash": "sha256-uNszcul7y++oBiyYXjHEDw/AHeLNp8B6pyWOB+RLA/4=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "42f30f55ec9d396b67c456683b4409cd7d07fc7b",
+        "rev": "94792ab2a6beaec81424445bf917ca2556fbeade",
         "type": "github"
       },
       "original": {
         "owner": "nixos",
-        "ref": "nixpkgs-24.05-darwin",
+        "ref": "nixpkgs-24.11-darwin",
         "repo": "nixpkgs",
         "type": "github"
       }
     },
     "nixpkgs-unstable": {
       "locked": {
-        "lastModified": 1735268880,
-        "narHash": "sha256-7QEFnKkzD13SPxs+UFR5bUFN2fRw+GlL0am72ZjNre4=",
+        "lastModified": 1739138025,
+        "narHash": "sha256-M4ilIfGxzbBZuURokv24aqJTbdjPA9K+DtKUzrJaES4=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "7cc0bff31a3a705d3ac4fdceb030a17239412210",
+        "rev": "b2243f41e860ac85c0b446eadc6930359b294e79",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -2,13 +2,13 @@
   description = "crdant's system configration ";
 
   inputs = {
-    nixpkgs.url = "github:nixos/nixpkgs/nixpkgs-24.05-darwin";
+    nixpkgs.url = "github:nixos/nixpkgs/nixpkgs-24.11-darwin";
     nixpkgs-unstable.url = "github:nixos/nixpkgs/nixpkgs-unstable";
 
-    home-manager.url = "github:nix-community/home-manager/release-24.05";
+    home-manager.url = "github:nix-community/home-manager/release-24.11";
     home-manager.inputs.nixpkgs.follows = "nixpkgs";
 
-    darwin.url = "github:lnl7/nix-darwin";
+    darwin.url = "github:lnl7/nix-darwin/nix-darwin-24.11";
     darwin.inputs.nixpkgs.follows = "nixpkgs"; # ...
 
     _1password-shell-plugins.url = "github:1Password/shell-plugins";

--- a/pkgs/kots/default.nix
+++ b/pkgs/kots/default.nix
@@ -2,16 +2,16 @@
 
 buildGoModule rec {
   pname = "kots";
-  version = "1.120.0";
+  version = "1.124.3";
 
   src = fetchFromGitHub {
     owner = "replicatedhq";
     repo = "kots";
     rev = "v${version}";
-    sha256 = "sha256-vtFXKkGSPMeTimiyelyaX7SHls52j1U+sp9umm6u9Mc=";
+    sha256 = "sha256-pbzxCNqv288KmHjWYgovZmOX5a19+5gzCAlfg9abX8Q=";
   };
 
-  vendorHash = "sha256-Qo8hG/T9jbqZvsyxr46jp6V8GFE7hmoa+MPplKATs4Y="; 
+  vendorHash = "sha256-krs/Uqp5yQl7v/FXPvzUwMq3UVtXE2gDsCnDzGmUapE="; 
 
   subPackages = [ "cmd/kots/" ];
 

--- a/pkgs/mods/default.nix
+++ b/pkgs/mods/default.nix
@@ -2,16 +2,16 @@
 
 buildGoModule rec {
   pname = "mods";
-  version = "1.6.0";
+  version = "1.7.0";
 
   src = fetchFromGitHub {
     owner = "charmbracelet";
     repo = "mods";
     rev = "v${version}";
-    sha256 = "sha256-1Qx3P1q7zmrzNqmiivri0BxdEsRYgS1cOp17S44jRPI=";
+    sha256 = "sha256-wzLYkcgUWPzghJEhYRh7HH19Rqov1RJAxdgp3AGnOTY=";
   };
 
-  vendorHash = "sha256-LarOXYkyhSCMXkD2G3/XYHnj5bDcL6nwWxlMAYy+9d8=";
+  vendorHash = "sha256-L+4vkh7u6uMm5ICMk8ke5RVY1oYeKMYWVYYq9YqpKiw=";
 
   # nativeBuildInputs = [ installShellFiles pkg-config ];
 

--- a/pkgs/replicated/default.nix
+++ b/pkgs/replicated/default.nix
@@ -2,16 +2,16 @@
 
 buildGoModule rec {
   pname = "replicated";
-  version = "0.83.13";
+  version = "0.94.0";
 
   src = fetchFromGitHub {
     owner = "replicatedhq";
     repo = "replicated";
     rev = "v${version}";
-    sha256 = "sha256-BTgxlCWCg7fzmfUu8VEKCvKW9IN5h3DrS88ExC62MQU=";
+    sha256 = "sha256-xOpKsTjAjntf1BypK8nHHPLqkSBcKJZ6s8xPfTj4SZU=";
   };
 
-  vendorHash = "sha256-YMIB8GAX3DpZ8eazEugOeoLD4Yp84kbWuZdYBG4IWbw=";
+  vendorHash = "sha256-D6DcEyH958NxN861ikEegmpDR090qFfqdMxd7mmX41M=";
 
   subPackages = [ "cli/cmd/" ];
   ldflags = [

--- a/pkgs/sbctl/default.nix
+++ b/pkgs/sbctl/default.nix
@@ -7,15 +7,15 @@ let
   isLinux = stdenv.isLinux;
 in stdenv.mkDerivation rec {
   pname = "troubeleshoot-sbctl";
-  version = "0.14.0";
+  version = "0.17.0";
 
   src = fetchzip {
     url = "https://github.com/replicatedhq/sbctl/releases/download/v${version}/sbctl_${os}_${arch}.tar.gz";
     stripRoot = false;
     sha256 = if isDarwin then
-        "sha256-r+Mfv3IWRNfx449gcdtq+xxrLwY3XeNxZOfGqEdVnGo="
+        "sha256-riJyiKMdxpX5MckdOex8TA1Cu2W9Gt7Bw+O+8ILFDj4="
       else
-        "sha256-kqhtkCK4vmHRgbGQeqnnmUMHlCkMXi2l/LU1L8z/7ok=";
+        "";
   };
 
   # Install the binary

--- a/pkgs/vimr/default.nix
+++ b/pkgs/vimr/default.nix
@@ -2,12 +2,12 @@
 
 stdenv.mkDerivation rec {
   pname = "vimr";
-  version = "v0.49.0";
-  build = "20241006.202133";
+  version = "v0.51.0";
+  build = "20250129.234141";
 
   src = fetchurl {
     url = "https://github.com/qvacua/vimr/releases/download/${version}-${build}/VimR-${version}.tar.bz2";
-    sha256 = "sha256-b+BA4ABy/Wjsxnz9LQyR5ZEZOQGHk1Oiq03y2I6l9Vc=";
+    sha256 = "sha256-TjWKkkRHUjTZBOToqm245qaCgtSWlXxZyADLS2s52tE=";
   };
 
   dontFixup = true;


### PR DESCRIPTION
TL;DR
-----

Updates flakes and changes version for custom packages

Details
-------

Locks flake dependencies to newer versions and bumps versions for the
following packages that are defined in this flake:

* `kots`
* `mods`
* `replicated`
* `sbctl`
* `vimr`

Each of those packages is bumped to their latest release.
