### PR TITLE
Re-enables documentation on Darwin

### DIFF
--- a/hosts/darwin.nix
+++ b/hosts/darwin.nix
@@ -1,7 +1,7 @@
 { pkgs, ... }:
 {
 
-  documentation.enable = false ;
+  documentation.enable = true ;
 
   imports = [
     ./common.nix


### PR DESCRIPTION
TL;DR
-----

Turns documentation back on for Nix Darwin configuration

Details
-------

There was a bug for a while where having documentation enabled in the Nix
Darwin configuration would cause the build to fail. I had turned if off to
move forward. I tried turning it on for my most recent builds to see that
happened.

This changes persists the return to enabling documentation.

