### PR TITLE
References the renamed 1password CLI package

### DIFF
--- a/hosts/common.nix
+++ b/hosts/common.nix
@@ -58,7 +58,7 @@
 
   environment = {
     systemPackages = with pkgs; [
-      _1password
+      _1password-cli
       unstable.age
       coreutils
       dogdns


### PR DESCRIPTION
TL;DR
-----

Updates the `1password` CLI package to the new name

Details
-------

Changes Darwin host configuration to use the new `_1password-cli`
package name from Nix packages.
