### PR TITLE
Installs Ghosty as a cask

### DIFF
--- a/hosts/darwin.nix
+++ b/hosts/darwin.nix
@@ -47,7 +47,6 @@
     };
     
     brews = [
-      "ghostty"
       "llm"
     ];
 
@@ -73,6 +72,7 @@
       "font-inconsolata"
       "font-noto-sans"
       "font-open-sans"
+      "ghostty"
       "google-chrome"
       "google-drive"
       "grandperspective"


### PR DESCRIPTION
TL;DR
-----

Removes attempt to install a Ghostty brew and uses the cask

Detiails
--------

Corrects Darwin configuration error where the `ghostty` cask was
referenced as a brew instead of a cask.  While I was add it, I switched
to use the "tip" version for the very latest version of Ghosty.
