### PR TITLE
Overlays latest aider and adds to vim

### DIFF
--- a/overlays/default.nix
+++ b/overlays/default.nix
@@ -37,6 +37,17 @@
         };
       }
     );
+    aider-chat = prev.aider-chat.overridePythonAttrs (oldAttrs: let
+        newVersion = "0.75.1";
+      in {
+        src = oldAttrs.src // {
+          owner = "Aider-AI";
+          repo = "aider";
+          rev = "v${newVersion}";
+          hash = "sha256-TQDYrkSW58E1/lIBuJsgpXst8OAbaTyNX1SM8mdFgzU=";  
+        };
+      }
+    );
     buildGoModule = prev.buildGoModule.override {
       go = final.go;
     };

--- a/users/crdant/home.nix
+++ b/users/crdant/home.nix
@@ -66,7 +66,7 @@ in {
 
     # Specify packages not explicitly configured below
     packages = with pkgs; [
-      unstable.aider-chat
+      aider-chat
       argocd
       azure-cli
       certbot-full
@@ -391,7 +391,7 @@ in {
       vimAlias = true;
 
       plugins = with pkgs.vimPlugins; [
-
+        nvim-aider
         cmp-nvim-lsp
         conflict-marker-vim
         # copilot-vim


### PR DESCRIPTION
TL;DR
-----

Adds an overlay to use a newer version of aider

Details
-------

Aider released support for Sonnet 3.7 pretty quikcly and the even the
unstabe Nix package didn't keep up. Adds an overlay so I could use the
new version and let me stay more on top of it.
