### PR TITLE
Adds `llm` CLI with plugins I prefer

### DIFF
--- a/overlays/default.nix
+++ b/overlays/default.nix
@@ -51,10 +51,21 @@
     buildGoModule = prev.buildGoModule.override {
       go = final.go;
     };
+
     vimPlugins = prev.vimPlugins // {
       supermaven-vim = prev.callPackage ./supermaven-nvim { };
       nvim-aider = prev.callPackage ./nvim-aider { };
     };
+
+    python3Packages = prev.python3Packages // {
+      llm-anthropic = prev.callPackage ./llm-anthropic { };
+      llm-gemini = prev.callPackage ./llm-perplexity { };
+      llm-groq = prev.callPackage ./llm-groq { };
+      llm-mlx = prev.callPackage ./llm-mlx { };
+      llm-perplexity = prev.callPackage ./llm-perplexity { };
+    };
+
+    llm = prev.callPackage ./llm { };
   };
 
   # When applied, the unstable nixpkgs set (declared in the flake inputs) will

--- a/overlays/llm/default.nix
+++ b/overlays/llm/default.nix
@@ -1,0 +1,75 @@
+{ pkgs ? import <nixpkgs> {} }:
+
+let
+  unstable = import (fetchTarball "https://github.com/NixOS/nixpkgs/archive/nixos-unstable.tar.gz") {
+    inherit (pkgs) system;
+  };
+  # MLX is only supported on Apple Silicon, and I only use that with Darwin
+  mlx = if pkgs.stdenv.isDarwin && pkgs.stdenv.isAarch64 then unstable.python312Packages.mlx else null;
+
+  # Create a single, consistent Python environment
+  # This ensures all packages use the exact same Python version
+
+  customPython = unstable.python3.override {
+    packageOverrides = self: super: {
+      anthropic = unstable.python312Packages.anthropic.overrideAttrs (oldAttrs: let
+        newVersion = "0.49.0";
+        in {
+          version = newVersion;
+          src = unstable.fetchFromGitHub {
+            owner = "anthropics";
+            repo = "anthropic-sdk-python";
+            rev = "v${newVersion}";
+            hash = "sha256-vbK8rqCekWbgLAU7YlHUhfV+wB7Q3Rpx0OUYvq3WYWw=";
+          };
+        }
+      );
+ 
+      llm = unstable.python312Packages.llm.overrideAttrs (oldAttrs: let
+        newVersion = "0.23";
+        in {
+          version = newVersion;
+          src = unstable.fetchFromGitHub {
+            owner = "simonw";
+            repo = "llm";
+            rev = newVersion;
+            hash = "sha256-jUWhdLZLHgrIP7trHvLBETQ764+k4ze5Swt2HYMqg4E=";
+          };
+        }
+      );
+ 
+      groq = unstable.python312Packages.groq;
+      mlx = mlx;
+      mlx-lm = if mlx != null then self.callPackage ./mlx-lm { } else null;
+    };
+    self = customPython;  # This makes it self-referential
+  };
+  
+  # Now use this SAME customPython for all package definitions
+  llm-anthropic = pkgs.callPackage ./llm-anthropic { python3 = customPython; };
+  llm-gemini = pkgs.callPackage ./llm-gemini { python3 = customPython; };
+  llm-groq = pkgs.callPackage ./llm-groq { python3 = customPython; };
+  llm-mlx = pkgs.callPackage ./llm-mlx { python3 = customPython; };
+  llm-perplexity = pkgs.callPackage ./llm-perplexity { python3 = customPython; };
+  
+  # Only include llm-mlx on Darwin/Apple Silicon
+  darwinPlugins = if pkgs.stdenv.isDarwin && pkgs.stdenv.isAarch64 && mlx != null then
+    [ (pkgs.callPackage ./llm-mlx { python3 = customPython; }) ]
+    else [];
+  
+  commonPlugins = [
+    (pkgs.callPackage ./llm-anthropic { python3 = customPython; })
+    (pkgs.callPackage ./llm-gemini { python3 = customPython; })
+    (pkgs.callPackage ./llm-groq { python3 = customPython; })
+    (pkgs.callPackage ./llm-perplexity { python3 = customPython; })
+  ];
+
+  # Combine all plugins
+  allPlugins = commonPlugins ; # ++ darwinPlugins;
+  
+  # Create the Python environment
+  pythonEnv = customPython.withPackages (ps: [ customPython.pkgs.llm ] ++ allPlugins);
+in
+  pkgs.writeShellScriptBin "llm" ''
+    exec ${pythonEnv}/bin/llm "$@"
+  ''

--- a/overlays/llm/llm-anthropic/default.nix
+++ b/overlays/llm/llm-anthropic/default.nix
@@ -4,16 +4,16 @@
   fetchFromGitHub,
 }:
 
-python3.pkgs.buildPythonApplication rec {
+python3.pkgs.buildPythonPackage rec {
   pname = "llm-anthropic";
-  version = "0.13";
+  version = "0.15.1";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "simonw";
     repo = "llm-anthropic";
     rev = version;
-    hash = "sha256-eIppCyFu/2VKExkO88iRozC9AVDcRQaUKrNeLU89rrQ=";
+    hash = "sha256-8bVs3MJteOTCiw7n/4pMf+oXMhsQbCSzUFVQqm2ezcE=";
   };
 
   build-system = [

--- a/overlays/llm/llm-gemini/default.nix
+++ b/overlays/llm/llm-gemini/default.nix
@@ -4,42 +4,46 @@
   fetchFromGitHub,
 }:
 
-python3.pkgs.buildPythonApplication rec {
-  pname = "llm-mlx";
-  version = "0.2.1";
+python3.pkgs.buildPythonPackage rec {
+  pname = "llm-gemini";
+  version = "0.11";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "simonw";
-    repo = "llm-mlx";
+    repo = "llm-gemini";
     rev = version;
-    hash = "sha256-ePThUA7oB5Q9cTOOCoCrGUn/caSmasudE68dnGHtbNA=";
+    hash = "sha256-xYtfIajEU1iqHvSPDLmg9lHEllcKpVYyUuNZUGNcccw=";
   };
 
   build-system = [
     python3.pkgs.setuptools
+    python3.pkgs.wheel
   ];
 
   dependencies = with python3.pkgs; [
+    httpx
+    ijson
     llm
-    mlx-lm
   ];
 
   optional-dependencies = with python3.pkgs; {
     test = [
+      nest-asyncio
       pytest
+      pytest-recording
     ];
   };
 
   pythonImportsCheck = [
-    "llm_mlx"
+    "llm_gemini"
   ];
 
   meta = {
-    description = "Support for MLX models in LLM";
-    homepage = "https://github.com/simonw/llm-mlx";
+    description = "LLM plugin to access Google's Gemini family of models";
+    homepage = "https://github.com/simonw/llm-gemini";
     license = lib.licenses.asl20;
     maintainers = with lib.maintainers; [ ];
-    mainProgram = "llm-mlx";
+    mainProgram = "llm-gemini";
   };
 }

--- a/overlays/llm/llm-groq/default.nix
+++ b/overlays/llm/llm-groq/default.nix
@@ -4,16 +4,16 @@
   fetchFromGitHub,
 }:
 
-python3.pkgs.buildPythonApplication rec {
-  pname = "llm-gemini";
-  version = "0.11";
+python3.pkgs.buildPythonPackage rec {
+  pname = "llm-grop";
+  version = "0.8";
   pyproject = true;
 
   src = fetchFromGitHub {
-    owner = "simonw";
-    repo = "llm-gemini";
-    rev = version;
-    hash = "sha256-xYtfIajEU1iqHvSPDLmg9lHEllcKpVYyUuNZUGNcccw=";
+    owner = "angerman";
+    repo = "llm-groq";
+    rev = "v${version}";
+    hash = "sha256-sZ5d9w43NvypaPrebwZ5BLgRaCHAhd7gBU6uHEdUaF4=";
   };
 
   build-system = [
@@ -22,28 +22,28 @@ python3.pkgs.buildPythonApplication rec {
   ];
 
   dependencies = with python3.pkgs; [
-    httpx
-    ijson
+    groq
     llm
   ];
 
   optional-dependencies = with python3.pkgs; {
     test = [
-      nest-asyncio
+      cogapp
       pytest
+      pytest-asyncio
       pytest-recording
     ];
   };
 
   pythonImportsCheck = [
-    "llm_gemini"
+    "llm_groq"
   ];
 
   meta = {
-    description = "LLM plugin to access Google's Gemini family of models";
-    homepage = "https://github.com/simonw/llm-gemini";
+    description = "LLM access to models hosted by Groq";
+    homepage = "https://github.com/angerman/llm-groq";
     license = lib.licenses.asl20;
     maintainers = with lib.maintainers; [ ];
-    mainProgram = "llm-gemini";
+    mainProgram = "llm-groq";
   };
 }

--- a/overlays/llm/llm-mlx/default.nix
+++ b/overlays/llm/llm-mlx/default.nix
@@ -1,0 +1,45 @@
+{
+  lib,
+  python3,
+  fetchFromGitHub,
+}:
+
+python3.pkgs.buildPythonPackage rec {
+  pname = "llm-mlx";
+  version = "0.2.1";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "simonw";
+    repo = "llm-mlx";
+    rev = version;
+    hash = "sha256-ePThUA7oB5Q9cTOOCoCrGUn/caSmasudE68dnGHtbNA=";
+  };
+
+  build-system = [
+    python3.pkgs.setuptools
+  ];
+
+  dependencies = with python3.pkgs; [
+    llm
+    mlx-lm
+  ];
+
+  optional-dependencies = with python3.pkgs; {
+    test = [
+      pytest
+    ];
+  };
+
+  pythonImportsCheck = [
+    "llm_mlx"
+  ];
+
+  meta = {
+    description = "Support for MLX models in LLM";
+    homepage = "https://github.com/simonw/llm-mlx";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ ];
+    mainProgram = "llm-mlx";
+  };
+}

--- a/overlays/llm/llm-perplexity/default.nix
+++ b/overlays/llm/llm-perplexity/default.nix
@@ -4,7 +4,7 @@
   fetchFromGitHub,
 }:
 
-python3.pkgs.buildPythonApplication rec {
+python3.pkgs.buildPythonPackage rec {
   pname = "llm-perplexity";
   version = "2025.2.0";
   pyproject = true;

--- a/overlays/llm/mlx-lm/default.nix
+++ b/overlays/llm/mlx-lm/default.nix
@@ -1,0 +1,38 @@
+# ./mlx-lm/default.nix
+{
+  lib,
+  python3,
+  fetchPypi,
+}:
+
+python3.pkgs.buildPythonPackage rec {
+  pname = "mlx-lm";  # Note: using underscore in pname as it appears on PyPI
+  version = "0.21.5";  # Updated to the latest version
+  format = "wheel";
+  
+  src = fetchPypi {
+    inherit pname version;
+    format = "wheel";
+    python = "py3";
+    dist = "py3";
+    platform = "any";
+    # You'll need to get the actual hash
+    sha256 = "05hzlbdd0s4nr5q0nfl1730ka1inbr76yaszlz71iayyj0hjj05g"; 
+  };
+  
+  # Add required dependencies
+  propagatedBuildInputs = with python3.pkgs; [
+    # List dependencies here
+    # You might need to check the package metadata for actual dependencies
+    mlx
+  ];
+  
+  doCheck = false;
+  pythonImportsCheck = [ "mlx_lm" ];
+  
+  meta = {
+    description = "MLX language models for Apple Silicon";
+    homepage = "https://pypi.org/project/mlx/";
+    license = lib.licenses.mit;  # Update with the correct license
+  };
+}

--- a/users/crdant/home.nix
+++ b/users/crdant/home.nix
@@ -105,10 +105,7 @@ in {
       oras
       packer
       pyright
-      unstable.llm
-      # llm-anthropic
-      # llm-perplexity
-      # llm-gemini
+      llm
       rar
       ripgrep
       replicated


### PR DESCRIPTION
Tl;DR
-----

Implements the \`llm` CLI as an overaly with plugings included

Details
-------

Installs the LLM plugin for my account with the following plugins:

* [anthropic](https://github.com/simonw/llm-anthropic)
* [gemini](https://github.com/simonw/llm-gemini)
* [groq](https://github.com/angerman/llm-groq)
* [perplexity](https://github.com/simonw/llm-perplexity)

Should also install the MLX plugin, but the packages aren't right yet so
that stuf is commented out for now.
