### PR TITLE
Switches from basic to fully loaded Aider

### DIFF
--- a/users/crdant/home.nix
+++ b/users/crdant/home.nix
@@ -67,7 +67,7 @@ in {
 
     # Specify packages not explicitly configured below
     packages = with pkgs; [
-      unstable.aider-chat
+      unstable.aider-chat-full
       argocd
       azure-cli
       certbot-full


### PR DESCRIPTION
TL;DR
-----

Enables a bunch of `aider` addons

Details
-------

Uses the `aider-chat-full` package which is "batteries included" and
includes the full help, web access through puppeteer, access to Bedrock,
and more. Currently it's only in the `unstable` channel, so we're
getting it from there.
