### PR TITLE
Configures SOPS for Home Manager

### DIFF
--- a/.sops.yaml
+++ b/.sops.yaml
@@ -1,0 +1,5 @@
+creation_rules:
+- path_regex: secrets/[^/]+\.(yaml|json|env|ini)$
+  pgp: 905EBD494A6AA2B774ED5C67621620CDA290611D
+- path_regex: users/crdant/secrets.yaml
+  pgp: 905EBD494A6AA2B774ED5C67621620CDA290611D

--- a/flake.lock
+++ b/flake.lock
@@ -113,13 +113,48 @@
         "type": "github"
       }
     },
+    "nixpkgs_2": {
+      "locked": {
+        "lastModified": 1744502386,
+        "narHash": "sha256-QAd1L37eU7ktL2WeLLLTmI6P9moz9+a/ONO8qNBYJgM=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "f6db44a8daa59c40ae41ba6e5823ec77fe0d2124",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
     "root": {
       "inputs": {
         "_1password-shell-plugins": "_1password-shell-plugins",
         "darwin": "darwin",
         "home-manager": "home-manager",
         "nixpkgs": "nixpkgs",
-        "nixpkgs-unstable": "nixpkgs-unstable"
+        "nixpkgs-unstable": "nixpkgs-unstable",
+        "sops-nix": "sops-nix"
+      }
+    },
+    "sops-nix": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_2"
+      },
+      "locked": {
+        "lastModified": 1744518500,
+        "narHash": "sha256-lv52pnfiRGp5+xkZEgWr56DWiRgkMFXpiGba3eJ3krE=",
+        "owner": "Mic92",
+        "repo": "sops-nix",
+        "rev": "7e147a1ae90f0d4a374938cdc3df3cdaecb9d388",
+        "type": "github"
+      },
+      "original": {
+        "owner": "Mic92",
+        "repo": "sops-nix",
+        "type": "github"
       }
     },
     "systems": {

--- a/flake.nix
+++ b/flake.nix
@@ -4,6 +4,7 @@
   inputs = {
     nixpkgs.url = "github:nixos/nixpkgs/nixpkgs-24.11-darwin";
     nixpkgs-unstable.url = "github:nixos/nixpkgs/nixpkgs-unstable";
+    sops-nix.url = "github:Mic92/sops-nix";
 
     home-manager.url = "github:nix-community/home-manager/release-24.11";
     home-manager.inputs.nixpkgs.follows = "nixpkgs";
@@ -13,6 +14,7 @@
 
     _1password-shell-plugins.url = "github:1Password/shell-plugins";
     _1password-shell-plugins.inputs.nixpkgs.follows = "home-manager"; # ...
+
   };
 
   outputs = { self, nixpkgs, home-manager, darwin, ...}@inputs: 

--- a/users/crdant/home.nix
+++ b/users/crdant/home.nix
@@ -10,6 +10,7 @@ in {
 
   imports = [
     inputs._1password-shell-plugins.hmModules.default
+    inputs.sops-nix.homeManagerModules.sops
   ];
 
   nixpkgs = {
@@ -30,6 +31,16 @@ in {
       #   });
       # })
     ];
+  };
+
+  sops = {
+    defaultSopsFile = ./secrets.yaml;  # Path to your secrets file
+    gnupg = {
+      home = "${config.home.homeDirectory}/.gnupg";
+    };
+    secrets = {
+      "github/token" = {};
+    } ; 
   };
 
   home = {

--- a/users/crdant/secrets.yaml
+++ b/users/crdant/secrets.yaml
@@ -1,0 +1,27 @@
+github:
+    token: ENC[AES256_GCM,data:k0z0LA==,iv:vXTjlwhCTTCyt/1glBR+vqGbt78y8BXh/+etNO7bFIw=,tag:XcKg2EvQuYaD1fZJt/74sw==,type:str]
+google:
+    maps:
+        api_key: ENC[AES256_GCM,data:aeBPcxpXY5RuyUlG,iv:IOruYqnTLXo0w8cvsZvI99lzH1xMzNRMOFzgF1EJQtE=,tag:7XM4tu/YKrdk2oTB8TN8Cg==,type:str]
+sops:
+    kms: []
+    gcp_kms: []
+    azure_kv: []
+    hc_vault: []
+    age: []
+    lastmodified: "2025-04-14T04:16:41Z"
+    mac: ENC[AES256_GCM,data:rS1c6qi3sOoHJHtHREjo9wO4wc2wXOT80fQK/8IniinLmGrLH4tFdkxtkW1AshPp0W60tK0wvQnTq0XTWkQe/vDKiBHmoVGRxFOLiSIYGDlfkaTaZplJzmZ8sd2IAZkuw0M8Qsw0HJ0WTt4l9sSI8/FEm3DfpSG4Db/5305tak8=,iv:kACSmydMiW8NJLOiiDLB7HLn0NaYTV3O4MwArLJVpuM=,tag:MpgqLj0CtAHFgP1zTiu9ZA==,type:str]
+    pgp:
+        - created_at: "2025-04-14T04:07:12Z"
+          enc: |-
+            -----BEGIN PGP MESSAGE-----
+
+            hF4DYhYgzaKQYR0SAQdAVBKHuQ7jdE4b1JTQ68eghsuvpwQHKg+VBWYkU7BLZEkw
+            D/E2qLQCHOPNSsIPWGa+m4pqkjxjOTutBq3sRLYD1rsNiXxdE1qNfWk6Q3DfW8kC
+            0l4BZ7uGdSr9gVFzJtkSpO+VV54198y/nHkqkbnRAQ40u0QN/1ww2QIhLrjtTcR9
+            FRCXt52vDovP5I+ZyKaP2hbPoVCiBDubZb1gA6W+axpwEuk7pNpTuYQzczy7l4Cn
+            =ocQE
+            -----END PGP MESSAGE-----
+          fp: 905EBD494A6AA2B774ED5C67621620CDA290611D
+    unencrypted_suffix: _unencrypted
+    version: 3.9.4


### PR DESCRIPTION
TL;DR
-----

Frames up what I need for SOPS in my Home Manager configuration

Details
-------

I use SOPS, I use Home Manager. I haven't used them together before, but
I've wanted to. This changes adds the necessary configurations to
incorporate SOPS secrets into my Home Manager configuration. Also adds
some fake secrets to assure they are encrypted. Reals secrets to come
when I need them.
