### PR TITLE
Removes redundant brew install of `llm`

### DIFF
--- a/hosts/darwin.nix
+++ b/hosts/darwin.nix
@@ -46,10 +46,6 @@
       upgrade = true;
     };
     
-    brews = [
-      "llm"
-    ];
-
     taps = [
       "homebrew/bundle"
       "homebrew/cask-drivers"


### PR DESCRIPTION
TL;DR
-----

Takes `llm` out of our brew installs since we install a package

Details
-------

Updates the default Darwin configuration to avoid installing `llm`
with hombrew now that it's installed with Nix.
