### PR TITLE
Adds the sample Github MCP server

### DIFF
--- a/users/crdant/home.nix
+++ b/users/crdant/home.nix
@@ -41,6 +41,54 @@ in {
     secrets = {
       "github/token" = {};
     } ; 
+  } // lib.optionalAttrs isDarwin {
+    templates = {
+      "claude_desktop_config.json" = {
+        path = "${config.home.homeDirectory}/Library/Application Support/Claude/claude_desktop_config.json";
+        mode = "0600";
+        content = 
+          let
+            # Define paths to be templated
+            nerdctlPath = "${config.home.homeDirectory}/.rd/bin/nerdctl";
+            uvxPath = "${pkgs.uv}/bin/uvx";
+            npxPath = "${pkgs.nodejs_22}/bin/npx";
+            
+            # User workspace path
+            workspacePath = "${config.home.homeDirectory}/workspace";
+          in
+          builtins.toJSON {
+            globalShortcut = "Cmd+Space";
+            mcpServers = {
+              fetch = {
+                command = uvxPath;
+                args = ["mcp-server-fetch"];
+              };
+              memory = {
+                command = npxPath;
+                args = ["-y" "@modelcontextprotocol/server-memory"];
+                env = {
+                  MEMORY_FILE_PATH = "${config.xdg.stateHome}/modelcontextprotocol/memory";
+                };
+              };
+              puppeteer = {
+                command = npxPath;
+                args = ["-y" "@modelcontextprotocol/server-puppeteer" ];
+              };
+              time = {
+                command = uvxPath;
+                args = ["mcp-server-time" "--local-timezone=America/New_York"];
+              };
+              github = {
+                command = npxPath;
+                args = ["-y" "@modelcontextprotocol/server-github" ];
+                env = {
+                  GITHUB_TOKEN = "${config.sops.placeholder."github/token"}";
+                };
+              };
+            };
+          };
+      };
+    };
   };
 
   home = {
@@ -151,11 +199,10 @@ in {
       # discord
       # minikube
       bruno
-      iterm-ai
+      # iterm-ai
       postman
       sourcekit-lsp
       swiftlint
-      unstable.darwin.xcode_16_2
       unstable.xcodegen
       vimr
       (callPackage ./vimr-wrapper.nix { inherit config ; })
@@ -237,42 +284,6 @@ in {
       #   recursive = true;
       # };
 
-      "Library/Application Support/Claude/claude_desktop_config.json" = {
-        text = 
-          let
-            # Define paths to be templated
-            nerdctlPath = "${config.home.homeDirectory}/.rd/bin/nerdctl";
-            uvxPath = "${pkgs.uv}/bin/uvx";
-            npxPath = "${pkgs.nodejs_22}/bin/npx";
-            
-            # User workspace path
-            workspacePath = "${config.home.homeDirectory}/workspace";
-          in
-          builtins.toJSON {
-            globalShortcut = "Cmd+Space";
-            mcpServers = {
-              fetch = {
-                command = uvxPath;
-                args = ["mcp-server-fetch"];
-              };
-              memory = {
-                command = npxPath;
-                args = ["-y" "@modelcontextprotocol/server-memory"];
-                env = {
-                  MEMORY_FILE_PATH = "${config.xdg.stateHome}/modelcontextprotocol/memory";
-                };
-              };
-              puppeteer = {
-                command = npxPath;
-                args = ["-y" "@modelcontextprotocol/server-puppeteer" ];
-              };
-              time = {
-                command = uvxPath;
-                args = ["mcp-server-time" "--local-timezone=America/New_York"];
-              };
-            };
-          };
-      };
     } ;
   };
 

--- a/users/crdant/secrets.yaml
+++ b/users/crdant/secrets.yaml
@@ -1,16 +1,13 @@
 github:
-    token: ENC[AES256_GCM,data:k0z0LA==,iv:vXTjlwhCTTCyt/1glBR+vqGbt78y8BXh/+etNO7bFIw=,tag:XcKg2EvQuYaD1fZJt/74sw==,type:str]
-google:
-    maps:
-        api_key: ENC[AES256_GCM,data:aeBPcxpXY5RuyUlG,iv:IOruYqnTLXo0w8cvsZvI99lzH1xMzNRMOFzgF1EJQtE=,tag:7XM4tu/YKrdk2oTB8TN8Cg==,type:str]
+    token: ENC[AES256_GCM,data:Fu5u7WKj8mw1Jt6knUs/nbiS2owgfCmspNJtSfDAYAcLLkZbd7wzaA==,iv:5/CKrPHZT/X0YQKEZw/rJla3FtslQBCstUP7arEBVUU=,tag:fs6xXU3Gz6bDM+fT27kLJA==,type:str]
 sops:
     kms: []
     gcp_kms: []
     azure_kv: []
     hc_vault: []
     age: []
-    lastmodified: "2025-04-14T04:16:41Z"
-    mac: ENC[AES256_GCM,data:rS1c6qi3sOoHJHtHREjo9wO4wc2wXOT80fQK/8IniinLmGrLH4tFdkxtkW1AshPp0W60tK0wvQnTq0XTWkQe/vDKiBHmoVGRxFOLiSIYGDlfkaTaZplJzmZ8sd2IAZkuw0M8Qsw0HJ0WTt4l9sSI8/FEm3DfpSG4Db/5305tak8=,iv:kACSmydMiW8NJLOiiDLB7HLn0NaYTV3O4MwArLJVpuM=,tag:MpgqLj0CtAHFgP1zTiu9ZA==,type:str]
+    lastmodified: "2025-04-14T04:57:39Z"
+    mac: ENC[AES256_GCM,data:WnXHQVLPjYXIHseEwsmhL7czdZlWudUNtHPsVJuWsy7ZYA6YrK49IaJl5DfZul+wmOyC9VDIHBbIqwHaWMW1yI/SZVD96Hn+InYb3fVG5Em8Vw3mkw0p1TJyvOY7Y2kJubuKClqjOfOQPruohu1G2hccff0uOXO/eeiuStlBaVg=,iv:VHk0LGnuVUBj91WrySvNvuC8YOxUureSu06cG4xa3+k=,tag:dDTDntV6QBN4WZDAdV2DGg==,type:str]
     pgp:
         - created_at: "2025-04-14T04:07:12Z"
           enc: |-


### PR DESCRIPTION
TL;DR
-----

Configures the sample Github MCP server into Claude Desktop

Details
-------

Starts bringing GitHub to Claude Desktop using the sample server from
the MCP repository. I should probably switch to the official server but
right now it only runs in Docker and I wanted to stick with running
directly with Node for now (that will change soon).

Also moves all of my Claude Desktop config from being configured as a
static file to being configured as a SOPS template. I'll be adding more
MCP servers that need API keys, auth tokens, etc. soon so this is a
welcome change. It's also needed to keep my GitHub access token safe.

Needless to say, the secrets in my home configuration are now real and
include a GitHub access token.
