### PR TITLE
Configures Aider to watch for direction in files

### DIFF
--- a/users/crdant/home.nix
+++ b/users/crdant/home.nix
@@ -61,6 +61,7 @@ in {
               multiline = true;
               vim = true;
 
+              watch-files = true;
               notifications = true;
             };
           in builtins.readFile content;


### PR DESCRIPTION
TL;DR
-----

Turns on the watch files option for Aider

Details
-------

Modifies my home environment so that `aider` will always run in watch
files mode. This means it will watch for comments asking it to either
answer questions or take action.
