### PR TITLE
Creates a git alias for unstashing specific files

### DIFF
--- a/users/crdant/home.nix
+++ b/users/crdant/home.nix
@@ -475,6 +475,7 @@ in {
         unignore = "update-index --no-skip-worktree";
         ignored = "!git ls-files -v | grep \"^S\"";
         praise = "blame";
+        unstash = "!f() { if [ $# -eq 0 ]; then echo \"Usage: git unstash <file1> [<file2> ...]\"; else for file in \"$@\"; do git checkout stash@{0} -- \"$file\"; done; fi }; f"
       };
 
       extraConfig = {


### PR DESCRIPTION
TL;DR
-----

Provides `git unstash <file>` to my home environment

Details
-------

Rcently found myself needing to unstash specific files from git a
couple of times and realied it would be cool to have a git alias for
it. This change adds that.
