### PR TITLE
Installs `xcbeautify` in my home environment

### DIFF
--- a/users/crdant/home.nix
+++ b/users/crdant/home.nix
@@ -308,6 +308,7 @@ in {
       sourcekit-lsp
       swiftlint
       terminal-notifier
+      xcbeautify
       unstable.xcodegen
       vimr
       (callPackage ./vimr-wrapper.nix { inherit config ; })


### PR DESCRIPTION
TL;DR
-----

Assures that `xcbeautify` is installed in my home environment

Details
-------

Incorporates the `xcbeautify` package so that I can use it when doing
command-line builds for Apple apps.
