### PR TITLE
Changes how `bash` is specified in `Makefile`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # Dynamic Makefile for Nix configurations using nix eval
 
 # Configuration variables
-SHELL := /bin/bash
+SHELL := /usr/bin/env bash
 FLAKE_PATH := .
 NIX := nix
 


### PR DESCRIPTION
TL;DR
-----

Uses `env` to specify the shell for `make`

Details
-------

Addresses the location of `bash` in NixOS by using `env` in the `Makefile` instead of a hard-coded path.