### PR TITLE
Uses a new version of Claude Code

### DIFF
--- a/overlays/default.nix
+++ b/overlays/default.nix
@@ -31,6 +31,19 @@
       go = final.go;
     };
 
+    claude-code = final.unstable.claude-code.overrideAttrs (oldAttrs: let
+      newVersion = "0.2.114"; # Your desired version
+      in {
+        version = newVersion;
+      
+        src = prev.fetchzip {
+          url = "https://registry.npmjs.org/@anthropic-ai/claude-code/-/claude-code-${newVersion}.tgz";
+          hash = "sha256-el6pRQaMczBTrpC+LA2i60BjEWe50WTZ1vogsCGi/y0="; # Update with correct hash
+        };
+        
+        npmDepsHash = ""; # Update with correct hash
+      });
+
     vimPlugins = prev.vimPlugins // {
       supermaven-vim = prev.callPackage ./supermaven-nvim { };
       nvim-aider = prev.callPackage ./nvim-aider { };

--- a/users/crdant/home.nix
+++ b/users/crdant/home.nix
@@ -364,11 +364,20 @@ in {
       zsh-completions
     ] ;
 
+    # HACK because Claude code won't follow symlinks, replace with commented out file
+    # stuff below as soon as possible
+    activation = {
+      claude = lib.hm.dag.entryAfter [ "writeBoundary" ] ''
+        $DRY_RUN_CMD mkdir -p ~/.claude/commands
+        $DRY_RUN_CMD cp -f ${./config/claude/commands}/* ~/.claude/commands/
+      '';
+    };
+
     file = {
-      ".claude" = {
-        source = ./config/claude;
-        recursive = true;
-      };
+      # ".claude" = {
+      #   source = ./config/claude;
+      #   recursive = true;
+      # };
 
       ".curlrc" = {
         text = "-fL";


### PR DESCRIPTION
TL;DR
-----

Updatses the version of Claude Code in my home environment

Details
-------

Adds an overlay to my home environment that bumps the version of
Claude Code to a newer version that the one currently available in Nix
unstable.

Alongside the version bump, updates my home environment to workaround
a bug in Cluade Code where it will not load slash commands using
symlinks. Currently there's a hacky workaround in place that copies
the slash comand content to the right place rather than linking to
them in the Nix store. That hack is sad, but it needs to be there
until Anthropic fixes their code.
