### PR TITLE
Avoids 1Password plugins on Linux

### DIFF
--- a/users/crdant/home.nix
+++ b/users/crdant/home.nix
@@ -433,6 +433,7 @@ in {
     _1password-shell-plugins = {
       enable = true;
       plugins = with pkgs; [
+      ] ++ lib.optionals isDarwin [
         awscli2
         gh
         ngrok


### PR DESCRIPTION
TL;DR
-----

Ackowledges that most of my Linux use is headless by not installing
the 1Password plugins since they won't work without the desktop app

Details
-------

Updates my home environmen to only configure 1Password plugins on
MacOS. This was an easy way to avoid dealing with them not working on
my headless Linux machines, since they depend on the desktop app for
permission to access 1Password.

I think I should be able to configure things the way I expected them
to work, but the documentation is inconsistent about that. This avoids
the pain without limiting any of my current use cases.
