### PR TITLE
Removes outdated Oh My Zsh plugins

### DIFF
--- a/users/crdant/home.nix
+++ b/users/crdant/home.nix
@@ -1015,9 +1015,7 @@ in {
           "kubectx"
           "helm"
           "history-substring-search"
-          "vault"
           "terraform"
-          "ripgrep"
           "zoxide"
           ] ++ pkgs.lib.optionals isDarwin [
             "brew"


### PR DESCRIPTION
TL;DR
-----

Stopes configuring plugins that are no longer part of of Oh My Zsh

Details
-------

For too long, I've been watching errors every time I start a new shell
saying that I'm trying to load the `vault` and `ripgrep` pluging for
Oh My Zsh. Today I finally looked into it and found that they've been
removed from Oh My Zsh since they aren't needed any longer.

This change removes those plugings from my home environment to make this going
away.
