### PR TITLE
Perserves from local changes from `mash`

### DIFF
--- a/hosts/common.nix
+++ b/hosts/common.nix
@@ -91,6 +91,7 @@
       knot-dns
       nmap
       neovim
+      nh
       opensc
       openssh
       powershell

--- a/hosts/linux.nix
+++ b/hosts/linux.nix
@@ -46,6 +46,7 @@
         "lab.shortrib.net"
         "crdant.net"
       ];
+      fallbackDns = [ "10.25.0.1" ];
     };
     openssh = {
       enable = true;

--- a/hosts/mash/default.nix
+++ b/hosts/mash/default.nix
@@ -5,6 +5,15 @@
     ../linux.nix 
   ];
 
+  system.stateVersion = "24.11";
+
+  boot.binfmt.emulatedSystems = [ 
+    "aarch64-linux"
+    "riscv64-linux"
+    "wasm32-wasi"
+    "mipsel-linux"
+  ];
+
   networking = {
     hostName = "mash";
     firewall = {


### PR DESCRIPTION
TL;DR
-----

Captures tweaks I'd made off-hand in the repo

Details
-------

Applies a few minor changes to the confiugration of the `mash` host
that I'd been using live without committing.

1. Installs the `nh` command for simpler Nix store cleanup
2. Makes sure local DNS is used
3. Enables emulation for RISC-V, ARM, WASM, and EdgeRouter
