### PR TITLE
Fixes primary user on darwin

### DIFF
--- a/users/crdant/chuck.nix
+++ b/users/crdant/chuck.nix
@@ -7,4 +7,11 @@
     home = "/Users/chuck";
     shell = pkgs.zsh;
   };
+
+  system = {
+    primaryUser = "chuck";
+    defaults = { 
+      screencapture.location = "/Users/chuck/Documents/Outbox";
+    };
+  };
 }

--- a/users/crdant/crdant.nix
+++ b/users/crdant/crdant.nix
@@ -31,6 +31,13 @@ in
       extraGroups = [ "adm" "ssher" "sudo" "wheel" ];
     };
 
+    system = {
+      primaryUser = "crdant";
+      defaults = { 
+        screencapture.location = "/Users/crdant/Documents/Outbox";
+      };
+    };
+
   } // lib.optionalAttrs isLinux {
     groups.crdant = {
       gid = 1002;

--- a/users/crdant/darwin.nix
+++ b/users/crdant/darwin.nix
@@ -30,9 +30,7 @@ in
   };
 
   system = {
-    primaryUser = "crdant";
     defaults = { 
-      screencapture.location = "/Users/crdant/Documents/Outbox";
       CustomUserPreferences = {
         # "com.apple.AddressBook" = addressbook;
         "com.if.Amphetamine" = amphetamine;


### PR DESCRIPTION
TL;DR
-----

Updates home environments so primary user is set correctly

Details
-------

Resolves issue where the primary user was set to my preferred `crdant`
username even on systems I configured with my username as `chuck`.
