### PR TITLE
Updates group configuration for sochu

### DIFF
--- a/hosts/sochu/default.nix
+++ b/hosts/sochu/default.nix
@@ -4,6 +4,8 @@
     ../darwin.nix 
   ];
 
+  ids.gids.nixbld = 30000;
+
   homebrew = {
     brews = [
       "chainguard-dev/tap/chainctl"


### PR DESCRIPTION
TL;DR
-----

Adapts the host `sochu` for it's Nix group configuration

Details
-------

Sets the group IDs for the `sochu` host to match the ones that were
already in place on that system.
