### PR TITLE
Enables Claude Code multi-line in Ghostty

### DIFF
--- a/users/crdant/config/ghostty/config
+++ b/users/crdant/config/ghostty/config
@@ -2,3 +2,4 @@ theme = dark:rose-pine-moon,light:rose-pine-dawn
 font-family = "Inconsolata Regular Regular"
 font-size = 11
 copy-on-select = true
+keybind = shift+enter=text:\n


### PR DESCRIPTION
TL;DR
-----

Makes multi-line input manageable with Shift+Enter

Details
-------

Anyone who's spent time crafting multi-line commands in the terminal knows the frustration: you're halfway through composing a complex git commit message or setting up environment variables, you need to add a line break, but pressing Enter executes the command prematurely. Your flow breaks, and you're back to square one.

This change solves that problem by adding a Shift+Enter keybinding that inserts a newline character without triggering command execution. It's a small fix that eliminates a persistent friction point in terminal workflows. Whether you're writing detailed commit messages, configuring multi-line environment variables, or building complex shell commands that need to span several lines for readability, you can now work without constantly fighting against the terminal's default behavior.

The implementation takes advantage of Ghostty's flexible keybinding system, mapping the intuitive Shift+Enter combination—already familiar from text editors and chat applications—to simple newline insertion. This consistency means you don't need to learn yet another keyboard shortcut; muscle memory from other applications transfers directly to your terminal experience.

_Honestly, I did this because Claude Code recommends it for entering multi-line text in it's interface, but there's a lot of extra benefit that my PR agent flow identified_
