### PR TITLE
Adds GitHub SSH key integration

### DIFF
--- a/users/crdant/crdant.nix
+++ b/users/crdant/crdant.nix
@@ -1,7 +1,12 @@
 { inputs, pkgs, lib, ... }:
+
 let
   isDarwin = pkgs.stdenv.isDarwin ;
   isLinux = pkgs.stdenv.isLinux ;
+
+  authorizedKeysFile = builtins.fetchurl {
+    url = "https://github.com/crdant.keys";
+  };
 
   authorizedKeys = let
       content = builtins.readFile authorizedKeysFile;
@@ -21,24 +26,25 @@ in
       shell = pkgs.zsh;
       description = "Chuck D'Antonio";
 
-      openssh.authorizedKeys.keys = authorizedKeys
+      openssh.authorizedKeys.keys = authorizedKeys;
 
     } // lib.optionalAttrs isLinux {
       isNormalUser = true;
       group = "crdant";
       extraGroups = [ "adm" "ssher" "sudo" "wheel" ];
     };
+  };
 
-    system = {
-      primaryUser = "crdant";
-      defaults = { 
-        screencapture.location = "/Users/crdant/Documents/Outbox";
-      };
+  system = {
+    primaryUser = "crdant";
+  } // lib.optionalAttrs isDarwin {
+    defaults = { 
+      screencapture.location = "/Users/crdant/Documents/Outbox";
     };
-
   } // lib.optionalAttrs isLinux {
     groups.crdant = {
       gid = 1002;
     };
   };
+
 }


### PR DESCRIPTION
TL;DR
-----

Streamlines setup of my SSH authorized keys by fetching SSH keys directly from GitHub

Details
------

Improves both security and convenience by retrieving my authorized keys directly from GitHub when building my home environment. This means I have a single source of turh for my SSH keys and automatically stay current. This eliminates the friction of manually updating configuration files whenever keys are rotated or modified.
