### PR TITLE
Aligns the `chuck` user with the `crdant` user

### DIFF
--- a/users/crdant/chuck.nix
+++ b/users/crdant/chuck.nix
@@ -19,11 +19,12 @@ in
 
     description = "Chuck D'Antonio";
 
-    openssh.authorizedKeys.keys = builtins.trace authorizedKeys authorizedKeys;
+    openssh.authorizedKeys.keys = authorizedKeys;
   };
 
   system = {
     primaryUser = "chuck";
+  } // lib.optionalAttrs isDarwin {
     defaults = { 
       screencapture.location = "/Users/chuck/Documents/Outbox";
     };


### PR DESCRIPTION
TL;DR
-----

Applies corrections from the `crdant` user to the `chuck` user

Details
-------

Makes sure some changes I made so that the `crdant` user is correct and
consistent for Nix 25.05 are applied to the `chuck` user as well.
