### PR TITLE
Fixes SSH_AUTH_SOCK logic 🤞

### DIFF
--- a/users/crdant/modules/base.nix
+++ b/users/crdant/modules/base.nix
@@ -233,7 +233,8 @@ in {
 
         # handle SSH differences between Prompt on iOS and a machine with Yubikey PGP available
         # if we're connected via a traditional SSH agent it's probably Prompt
-        if [[ -n "$SSH_AUTH_SOCK" ]]; then
+        GPG_AGENT_SSH_SOCK=$(gpgconf --list-dirs agent-ssh-socket)
+        if [[ "SSH_AUTH_SOCK" != "$GPG_AGENT_SSH_SOCK" ]]; then
           # use ssh signing with the provided key
           export GIT_CONFIG_COUNT=3
           export GIT_CONFIG_KEY_0=gpg.format
@@ -242,9 +243,6 @@ in {
           export GIT_CONFIG_VALUE_1=~/.ssh/id_charanda_enclave.pub
           export GIT_CONFIG_KEY_2=gpg.ssh.allowedSignersFile
           export GIT_CONFIG_VALUE_2=~/.config/git/allowed-signers
-        else 
-          # GPG Agent as SSH agent
-          export SSH_AUTH_SOCK=$(gpgconf --list-dirs agent-ssh-socket)
         fi
 
         # Tmux convenience functions


### PR DESCRIPTION
Adds SSH authentication environment detection

TL;DR
-----

Fixes SSH authentication detection to properly distinguish between Prompt on iOS and local GPG agents, resolving Git commit signing issues when working remotely.

Details
-------

When working across multiple devices—from mobile to workstation—maintaining a consistent Git workflow shouldn't require guesswork about which authentication method is active. The previous implementation made a flawed assumption: it treated any SSH connection with an authentication socket as originating from Prompt on iOS. This created authentication headaches when connecting from machines running their own GPG agents, since those systems also set the SSH_AUTH_SOCK environment variable.

The enhanced detection logic cuts through this ambiguity by directly comparing the current SSH_AUTH_SOCK with the GPG agent's SSH socket path. Rather than making assumptions based on the mere presence of an authentication socket, the system now knows definitively whether it's dealing with Prompt's SSH key signing or should defer to the local GPG agent.

This targeted fix ensures Git commits sign properly regardless of your connection method. Whether you're pushing code from an iPad using Prompt or working from a workstation with hardware security keys, the authentication flow adapts seamlessly. The result is a development workflow that works consistently across your entire device ecosystem, eliminating the friction of switching between mobile and desktop environments.
