### PR TITLE
Add repomix to the AI module for home environments

### DIFF
--- a/users/crdant/config/mcp.nix
+++ b/users/crdant/config/mcp.nix
@@ -50,5 +50,9 @@ in
       GOOGLE_MAPS_API_KEY = "${config.sops.placeholder."google/maps/apiKey"}";
     };
   };
+  repomix = {
+   command = npxPath;
+    args = [ "-y" "repomix" "--mcp" ];
+  };
 }
 

--- a/users/crdant/modules/ai.nix
+++ b/users/crdant/modules/ai.nix
@@ -12,9 +12,10 @@ in {
       unstable.fabric-ai
       goose-cli
       unstable.github-mcp-server
-      mbta-mcp-server
       llm
+      mbta-mcp-server
       mods
+      repomix
     ];
   
  
@@ -84,7 +85,30 @@ in {
               GOOSE_MODEL = "claude-3-7-sonnet-latest";
               GOOSE_MODE = "smart_approve";
               extensions = {
-                # ... your extensions config
+                computercontroller = {
+                  display_name = "Computer Controller";
+                  enabled = true;
+                  name = "computercontroller";
+                  timeout = 300;
+                  type = "builtin";
+                };
+                developer = {
+                  display_name = "Developer Tools";
+                  enabled = true;
+                  name = "developer";
+                  timeout = 300;
+                  type = "builtin";
+                };
+                git = {
+                  cmd = "${pkgs.uv}/bin/uvx";
+                  args = [ "mcp-server-git" ];
+                  description = "A Model Context Protocol server for Git repository interaction and automation.";
+                  envs = {};
+                  name = "git";
+                  enabled = true;
+                  timeout = 300;
+                  type = "stdio";
+                };
                 mbta = {
                   args = [ ];
                   cmd = "${pkgs.mbta-mcp-server}/bin/mbta-mcp-server";
@@ -97,7 +121,47 @@ in {
                   timeout = 300;
                   type = "stdio";
                 };
-                # ... rest of extensions
+                github = {
+                  args = [ "stdio" ];
+                  cmd = "${pkgs.unstable.github-mcp-server}/bin/github-mcp-server";
+                  description = "GitHub's official MCP Server";
+                  enabled = true;
+                  envs = {
+                    GITHUB_PERSONAL_ACCESS_TOKEN = config.sops.placeholder."github/token";
+                  };
+                  name = "github";
+                  timeout = 300;
+                  type = "stdio";
+                };
+                google-maps = {
+                  cmd = "${pkgs.nodejs_22}/bin/npx";
+                  args = [ "-y" "@modelcontextprotocol/server-google-maps" ];
+                  description = "MCP Server for the Google Maps API.";
+                  envs = {
+                    GOOGLE_MAPS_API_KEY = "${config.sops.placeholder."google/maps/apiKey"}";
+                  };
+                  name = "google-maps";
+                  enabled = true;
+                  timeout = 300;
+                  type = "stdio";
+                };
+                memory = {
+                  display_name = "Memory";
+                  enabled = true;
+                  name = "memory";
+                  timeout = 300;
+                  type = "builtin";
+                };
+                repomix = {
+                  display_name = "Repomix";
+                  description = "Pack your codebase into AI-friendly formats";
+                  cmd = "${pkgs.nodejs_22}/bin/npx";
+                  args = [ "-y" "@modelcontextprotocol/server-google-maps" ];
+                  enabled = true;
+                  name = "repomix";
+                  timeout = 300;
+                  type = "stdio";
+                };
               };
             };
             yamlContent = (pkgs.formats.yaml { }).generate "goose-config" gooseConfig;


### PR DESCRIPTION
TL;DR
-----

Installs Repomix and integrates its MCP server into the AI tooling environment

Details
-------

Strengthens our AI tooling configuration by integrating `repomix`, a CLI tool
and MCP server that transforms large codebases into AI-digestible formats.
Repomix addresses a fundamental challenge in AI-assisted development: bridging
the gap between sprawling repositories and the context limitations of AI
models by creating optimized representations that actually fit within
available context windows.

This integration touches multiple layers of the configuration. We've added
repomix to the installed packages in the AI module while simultaneously
configuring it as an MCP extension for Goose and Claude. 

