### PR TITLE
Moves Aider NeoVim plugin dependences to AI module

### DIFF
--- a/users/crdant/modules/ai.nix
+++ b/users/crdant/modules/ai.nix
@@ -183,7 +183,9 @@ in {
   programs = {
     neovim = {
       plugins = with pkgs.vimPlugins; [
-        # nvim-aider
+        neo-tree-nvim
+        nvim-aider
+        snacks-nvim
       ];
   
       extraLuaConfig = lib.mkAfter ''

--- a/users/crdant/modules/development.nix
+++ b/users/crdant/modules/development.nix
@@ -163,7 +163,6 @@ in {
         jupytext-nvim
         nvim-cmp
         nvim-lspconfig
-        snacks-nvim
         supermaven-nvim
         vim-surround
         vim-commentary


### PR DESCRIPTION
TL;DR
-----

Refactors Neovim plugin configs to include dependencies for Aider module in
the AI module.

Details
--------

Corrects issue with the `nvim-aider` plug by assuring it's dependencies are added to the AI home environment module.
