### PR TITLE
Shifts some fonts to Nerd Fonts

### DIFF
--- a/hosts/darwin.nix
+++ b/hosts/darwin.nix
@@ -30,7 +30,9 @@
       google-chrome
       grandperspective
       hexfiend
-      inconsolata
+      nerd-fonts.bitstream-vera-sans-mono
+      nerd-fonts.fira-code
+      nerd-fonts.inconsolata
       lima
       m-cli
       mas
@@ -62,9 +64,7 @@
     ];
 
     casks = [
-      "font-bitstream-vera"
       "font-cabin"
-      "font-fira-code"
       "font-noto-sans"
       "ghostty@tip"
       "google-drive"

--- a/users/crdant/defaults/vimr.nix
+++ b/users/crdant/defaults/vimr.nix
@@ -10,7 +10,7 @@
       };
       "appearance" = {
         "editor-characterspacing" = 1;
-        "editor-font-name" = "Menlo-Regular";
+        "editor-font-name" = "Fira-Code-Retina";
         "editor-font-size" = 13;
         "editor-linespacing" = 1;
         "editor-uses-ligatures" = 1;


### PR DESCRIPTION
TL;DR
-----

Moves some Homebrew-installed fonts to Nix-installed Nerd Fonts

Details
-------

Shifts font installation for coding/terminal fonts to Nerd Fonts managed
by Nix over the eariler Homebrew-managed installations of the base font.
Also update the default font for VimR.
