### PR TITLE
Updates logic that sets the SSH_AUTH_SOCK variable

### DIFF
--- a/users/crdant/modules/base.nix
+++ b/users/crdant/modules/base.nix
@@ -234,7 +234,7 @@ in {
         # handle SSH differences between Prompt on iOS and a machine with Yubikey PGP available
         # if we're connected via a traditional SSH agent it's probably Prompt
         GPG_AGENT_SSH_SOCK=$(gpgconf --list-dirs agent-ssh-socket)
-        if [[ "SSH_AUTH_SOCK" != "$GPG_AGENT_SSH_SOCK" ]]; then
+        if [[ -n "$SSH_AUTH_SOCK" && "$SSH_AUTH_SOCK" != "$GPG_AGENT_SSH_SOCK" ]]; then
           # use ssh signing with the provided key
           export GIT_CONFIG_COUNT=3
           export GIT_CONFIG_KEY_0=gpg.format
@@ -243,6 +243,10 @@ in {
           export GIT_CONFIG_VALUE_1=~/.ssh/id_charanda_enclave.pub
           export GIT_CONFIG_KEY_2=gpg.ssh.allowedSignersFile
           export GIT_CONFIG_VALUE_2=~/.config/git/allowed-signers
+        else
+          if [[ -z "$SSH_AUTH_SOCK" ]]; then
+            export SSH_AUTH_SOCK="$GPG_AGENT_SSH_SOCK"
+          fi
         fi
 
         # Tmux convenience functions


### PR DESCRIPTION
TL;DR
-----

Resolves issuses where the SSH_AUTH_SOCK variable was not set correctly

Details
-------

Updates the logic that sets the SSH_AUTH_SOCK variable in my shell to
avoid check against the value of the variable instead of its name. Also
sets the variable correctly in the case where it is not set.
