### PR TITLE
Corrects state verison conditional

### DIFF
--- a/systems/modules/base/default.nix
+++ b/systems/modules/base/default.nix
@@ -1,8 +1,38 @@
-{ inputs, outputs, pkgs, lib, ... }: 
+{ inputs, outputs, pkgs, lib, options, ... }: 
 let
-  isLinux = pkgs.stdenv.isLinux;
+  isLinux = pkgs.stdenv.isLinux; 
   isDarwin = pkgs.stdenv.isDarwin;
+
+  needsIntegerState = builtins.hasAttr "defaults" options.system;
+  stateVersion = {
+    stateVersion = if needsIntegerState then 5 else "24.11";
+  };
 in {
+  system = lib.mkMerge [
+    stateVersion
+  ];
+
+  # assure flakes and nix command are enabled
+  nix = {
+    extraOptions = ''
+      experimental-features = nix-command flakes
+      '';
+
+    registry = {
+      nixpkgs-unstable = {
+        from = {
+          id = "nixpkgs";
+          type = "indirect";
+        };
+        to = {
+          owner = "NixOS";
+          repo = "nixpkgs";
+          type = "github";
+          ref = "nixos-unstable";
+        };
+      };
+    };
+  };
 
   nixpkgs = {
     # You can add overlays here
@@ -26,28 +56,6 @@ in {
     config = {
       # Disable if you don't want unfree packages
       allowUnfree = true;
-    };
-  };
-
-  # assure flakes and nix command are enabled
-  nix = {
-    extraOptions = ''
-      experimental-features = nix-command flakes
-      '';
-
-    registry = {
-      nixpkgs-unstable = {
-        from = {
-          id = "nixpkgs";
-          type = "indirect";
-        };
-        to = {
-          owner = "NixOS";
-          repo = "nixpkgs";
-          type = "github";
-          ref = "nixos-unstable";
-        };
-      };
     };
   };
 

--- a/systems/modules/system-defaults/default.nix
+++ b/systems/modules/system-defaults/default.nix
@@ -5,13 +5,7 @@ let
   # this feels like a real hack, but I can't seem to figure out a cleaner way
   # that doesn't cause an infinite recursion
 
-  needsIntegerState = builtins.hasAttr "defaults" options;
-  stateVersion = {
-    stateVersion = if needsIntegerState
-      then 5
-      else "24.11";
-  };
-  supportsDarwinDefaults = builtins.hasAttr "defaults" options;
+  supportsDarwinDefaults = builtins.hasAttr "defaults" options.system;
   darwinDefaults = lib.optionalAttrs supportsDarwinDefaults {
     defaults = { 
       NSGlobalDomain = {
@@ -200,7 +194,6 @@ let
   systemOptions = {
     # Platform-specific system defaults and preferences
     system = (lib.mkMerge [
-      stateVersion
       darwinDefaults 
       resolvedConfig
       autoUpgradeConfig


### PR DESCRIPTION
TL;DR
-----

Fixes the logic for determine how to specify the state version

Details
-------

Cleans up the logic for determining the state version. The earlier
logic checked for the `defaults` attribute in the wrong place so it
alwyas used the string that NixOS expects.

Alos fixes the conditional for including MacOS defaults to check the
right place and moves the state version to the base module from the
system defaults module.
