### PR TITLE
Removes unused site-text fragments plugin

### DIFF
--- a/overlays/llm/default.nix
+++ b/overlays/llm/default.nix
@@ -109,7 +109,7 @@ let
   ];
   
   fragmentPlugins = [
-    llmPlugins.llm-fragments-site-text
+    # llmPlugins.llm-fragments-site-text
   ]; 
   
   templatePlugins = [


### PR DESCRIPTION
TL;DR
-----

Disables the site-text fragments plugin to avoid a failing dependency

Details
--------

Gets `llm` installing again by removing the site-text fragments plugin that I hadn't started using and which caused the install to fail. The plugin was causing the install to fail because on if it's dependencies has a failing test.

The fragments plugins list remains in place so I can add it to it later, and the entry for the failing plugin is commented out.
