### PR TITLE
Corrects Repomix MCP configuration for Goose

### DIFF
--- a/home/modules/ai/default.nix
+++ b/home/modules/ai/default.nix
@@ -156,7 +156,7 @@ in {
                   display_name = "Repomix";
                   description = "Pack your codebase into AI-friendly formats";
                   cmd = "${pkgs.nodejs_22}/bin/npx";
-                  args = [ "-y" "@modelcontextprotocol/server-google-maps" ];
+                  args = [ "-y" "repomix" "--mcp" ];
                   enabled = true;
                   name = "repomix";
                   timeout = 300;


### PR DESCRIPTION
TL;DR
-----

Replaces the copy/paste use of Google Maps MCP server as the Repomix
MCP sever

Details
--------

Corrects the Goose configuration in the AI module to use the Repomix
MCP server when it as the Repomix MCP server. It was previously
configured to use Google Maps as the MCP server as the Repomix server
due to a copy/paste error.
