### PR TITLE
Adds `tart` package for use in Homelab

### DIFF
--- a/home/modules/homelab/default.nix
+++ b/home/modules/homelab/default.nix
@@ -1,11 +1,16 @@
 { inputs, outputs, config, pkgs, lib, ... }:
+let 
+  isDarwin = pkgs.stdenv.isDarwin;
+  isLinux = pkgs.stdenv.isLinux;
+in {
 
-{
   home = {
     packages = with pkgs; [
       govc
       minio-client
       powershell
+    ] ++ lib.optionals isDarwin [
+      tart
     ];
     
     file = {

--- a/home/modules/infrastructure/default.nix
+++ b/home/modules/infrastructure/default.nix
@@ -5,16 +5,16 @@ let
   isLinux = pkgs.stdenv.isLinux;
 in {
   # Infrastructure and cloud-agnostic tools
-  home.packages = with pkgs; [
-    cloudflared
-    leftovers
-    packer
-    terraform
-    terraform-lsp
-    vault
-  ] ++ lib.optionals isDarwin [
-    tart
-  ];
+  home = {
+    packages = with pkgs; [
+      cloudflared
+      leftovers
+      packer
+      terraform
+      terraform-lsp
+      vault
+    ];
+  };
   
   programs = {
     # Terraform-specific Neovim configuration

--- a/home/modules/infrastructure/default.nix
+++ b/home/modules/infrastructure/default.nix
@@ -12,8 +12,9 @@ in {
     terraform
     terraform-lsp
     vault
+  ] ++ lib.optionals isDarwin [
+    tart
   ];
-
   
   programs = {
     # Terraform-specific Neovim configuration


### PR DESCRIPTION
TL;DR
-----

Provides the `tart` package in the Homelab home module.

Details
-------

I've recently bought a new Mac Mini to add to the lab. I'm planning to use
Tart to build machine images and run them using Mac-native virtualization on
the new box. Adds the `tart` package to accommodate this new architectural
decision.
