### PR TITLE
Adds Linux template path for LLM config

### DIFF
--- a/home/modules/ai/default.nix
+++ b/home/modules/ai/default.nix
@@ -38,6 +38,11 @@ in {
         source = ./config/llm/templates;
         recursive = true;
       };
+    } // lib.optionalAttrs isLinux {
+      "/home/crdant/.config/io.datasette.llm/templates" = {
+        source = ./config/llm/templates;
+        recursive = true;
+      };
     };
   };
 


### PR DESCRIPTION
TL;DR
-----

Ensures `llm` CLI template files are properly added to my home
environment on both Darwin and Linux systems by adding
platform-specific configuration paths.

Details
--------

The `llm` CLI templates were only being included to the
Darwin-specific path, leaving Linux users without access to the
template files. This change adds conditional linking for Linux systems
using the standard XDG config directory structure.
