### PR TITLE
Provides project-specific SSH configurations

### DIFF
--- a/home/modules/base/config/smug/window.yml
+++ b/home/modules/base/config/smug/window.yml
@@ -2,12 +2,12 @@ sendkeys_timeout: 0
 session: window
 windows:
 - name: zsh
-  root: /home/crdant/workspace/clusters
+  root: ~
   panes:
   - commands: []
   layout: tiled
 - name: nvim
-  root: /home/crdant/workspace/clusters
+  root: ~
   commands:
     - nvim
 

--- a/home/modules/base/default.nix
+++ b/home/modules/base/default.nix
@@ -249,6 +249,7 @@ in {
 
         function smug-session() {
           session=$1
+
           if [[ ! -d "$XDG_RUNTIME_DIR/ssh" ]]; then
             mkdir -p "$XDG_RUNTIME_DIR/ssh"
           fi
@@ -256,7 +257,11 @@ in {
             ln -sf $(readlink -f $SSH_AUTH_SOCK) "$XDG_RUNTIME_DIR/ssh/s.ssh-agent.smug-$session"
             export SSH_AUTH_SOCK="$XDG_RUNTIME_DIR/ssh/s.ssh-agent.smug-$session"
           fi
-          smug start $session
+          if [[ -f $(pwd)/.smug.yml ]]; then
+            smug start 
+          else
+            smug start $session
+          fi
         }
 
         function fullscreen() {

--- a/home/modules/homelab/config/ssh/config.d/projects
+++ b/home/modules/homelab/config/ssh/config.d/projects
@@ -1,0 +1,10 @@
+Match exec "[[ $(uname) == 'Darwin' ]]" host *.proj
+  RemoteCommand source ~/.zshrc && cd ~/workspace/projects/%h 
+  RequestTTY Yes
+  HostName mash
+  CanonicalizeHostName yes
+  CanonicalDomains walrus-shark.ts.net lab.shortrib.net 
+  StreamLocalBindUnlink yes
+  RemoteForward /run/user/1001/gnupg/S.gpg-agent %d/.gnupg/S.gpg-agent.extra 
+  RemoteForward /run/user/1001/gnupg/S.gpg-agent.ssh %d/.gnupg/S.gpg-agent.ssh
+


### PR DESCRIPTION
# Refines workspace setup with flexible navigation patterns

TL;DR
-----

Enhances my developer experience with configurable home directory starting points for terminal sessions and project-specific SSH connections.

Details
--------

Updates how SMUG works in my home environment to better accommodate project-specific configurations and streamline connections to remote workspaces. Terminal sessions now start in the home directory rather than a hard-coded path, giving me more flexibility in how I organize my work.

The `smug-session` function now intelligently detects configurations. When it discovers a `.smug.yml` file in the current directory, it automatically applies project-specific terminal settings that travel with the code. This means each project can define its own optimal workspace setup without affecting my global configuration.

These improvements integrate seamlessly with SSH configurations tailored to individual projects. When I connect to either the `pisco` or `mash` servers, the system automatically places me in the appropriate workspace directory. Simply using `<PROJECT>.mash` or `<PROJECT>.pisco` as hostnames lands me directly in `~/workspace/<PROJECT>` on the relevant server, eliminating the need to navigate after connecting.
