### PR TITLE
Makes sure watch is installed as essential

### DIFF
--- a/systems/modules/essential-packages/default.nix
+++ b/systems/modules/essential-packages/default.nix
@@ -1,33 +1,46 @@
-{ pkgs, lib, ... }:
+{ pkgs, lib, options,... }:
 
 let 
   isDarwin = pkgs.stdenv.isDarwin;
   isLinux = pkgs.stdenv.isLinux;
-in {
-  # Essential packages for system administration and daily use
-  
-  environment = {
-    systemPackages = with pkgs; [
-      coreutils
-      glow
-      gnumake
-      gnupg
-      home-manager
-      jq
-      neovim
-      nh
-      openssh
-      ripgrep
-      tailscale
-      tmux
-      tree
-      wget
-      yq-go
-      yubico-pam
-    ] ++ lib.optionals isDarwin [
-      mas
-      m-cli
-      darwin.trash
-    ];
+  supportsHomebrew = builtins.hasAttr "homebrew" options;
+  homebrewConfig = lib.optionalAttrs supportsHomebrew {
+    homebrew = {
+      enable = true;
+      brews = [
+        "watch"
+      ];
+    };
   };
-}
+in (lib.mkMerge [
+  {
+    # Essential packages for system administration and daily use
+    environment = {
+      systemPackages = with pkgs; [
+        coreutils
+        glow
+        gnumake
+        gnupg
+        home-manager
+        jq
+        neovim
+        nh
+        openssh
+        ripgrep
+        tailscale
+        tmux
+        tree
+        wget
+        yq-go
+        yubico-pam
+      ] ++ lib.optionals isDarwin [
+        mas
+        m-cli
+        darwin.trash
+      ] ++ lib.optionals isLinux [
+        unixtools.watch
+      ];
+    };
+  }
+  homebrewConfig
+])


### PR DESCRIPTION
TL;DR
-----

Ensures the watch command is available on both macOS and Linux platforms
through their appropriate package managers, enhancing system monitoring
capabilities.

Details
--------

Addresses platform-specific differences in delivering the watch utility
to users. Linux systems include watch through nixpkgs' unixtools.watch
package, while macOS receives it through Homebrew, which better handles
macOS-specific compatibility issuaes.

The watch command proves essential for system monitoring tasks, allowing
users to repeatedly run a command and observe its output change over
time. By ensuring consistent availability across platforms, this change
improves the experience for cross-platform developers who frequently
switch between environments.

The implementation intelligently detects whether Homebrew support exists
in the current configuration before attempting to enable it, making this
change robust across different system configurations.
