### PR TITLE
Moves the GitHub CLI to the development module

### DIFF
--- a/home/modules/cicd/default.nix
+++ b/home/modules/cicd/default.nix
@@ -8,7 +8,6 @@ in {
   home.packages = with pkgs; [
     argocd
     fluxcd
-    gh
     goreleaser
     tektoncd-cli
   ] ++ lib.optionals isLinux [
@@ -18,28 +17,6 @@ in {
   programs = {
     _1password-shell-plugins = {
       enable = true;
-      plugins = with pkgs; [
-        gh
-      ];
-    };
-    
-    gh = {
-      enable = true;
-      settings = {
-        aliases = {
-          co = "pr checkout";
-          pv = "pr view";
-        };
-        git_protocol = "ssh";
-      };
-    };
-    
-    zsh = {
-      oh-my-zsh = {
-        plugins = [
-          "gh"
-        ];
-      };
     };
   };
 }

--- a/home/modules/development/default.nix
+++ b/home/modules/development/default.nix
@@ -8,6 +8,7 @@ in {
   home = {
     packages = with pkgs; [
       exercism
+      gh
       git-filter-repo
       git-lfs
       unstable.cue
@@ -26,8 +27,20 @@ in {
       enable = true;
       plugins = with pkgs; [
       ] ++ lib.optionals isDarwin [
+        # gh
         ngrok
       ];
+    };
+       
+    gh = {
+      enable = true;
+      settings = {
+        aliases = {
+          co = "pr checkout";
+          pv = "pr view";
+        };
+        git_protocol = "ssh";
+      };
     };
     
     git = {
@@ -124,6 +137,7 @@ in {
   programs = { 
     zsh = { 
       oh-my-zsh.plugins = [
+        "gh"
         "git"
       ];
     };


### PR DESCRIPTION
TL;DR
-----

Shifts the GitHub CLI from the CI/CD module to the development module

Details
-------

Locates the GitHub CLI and its configuration int the development
module. It was formerly in the CI/CD module and that doesn't really
make sense since it's used for a lot more than that.
