### PR TITLE
Adds SOPS decryption support to Neovim

### DIFF
--- a/home/modules/security/default.nix
+++ b/home/modules/security/default.nix
@@ -46,6 +46,18 @@ in {
       ];
     };
     
+    neovim = {
+      # Core plugins used everywhere
+      plugins = with pkgs.vimPlugins; [
+        nvim-sops 
+      ];
+
+      extraLuaConfig = ''
+        vim.keymap.set('n', '<leader>ef', vim.cmd.SopsEncrypt, { desc = '[E]ncrypt [F]ile' })
+        vim.keymap.set('n', '<leader>df', vim.cmd.SopsDecrypt, { desc = '[D]ecrypt [F]ile' })
+      '';
+    };
+
     ssh = {
       enable = true;
       hashKnownHosts = true;


### PR DESCRIPTION
TL;DR
-----

Enables direct SOPS work in an existing instance by installing the
nvim-sops plugin

Details
--------

Incorpartes SOPS support into my Neovim configuration. This will
improve my workflow by keeping me from having to use a distinct Neovim
instance for secrets management.
