### PR TITLE
Resolves a bug with my auth sock magic

### DIFF
--- a/home/modules/base/default.nix
+++ b/home/modules/base/default.nix
@@ -206,7 +206,7 @@ in {
         # handle SSH differences between Prompt on iOS and a machine with Yubikey PGP available
         # if we're connected via a traditional SSH agent it's probably Prompt
         GPG_AGENT_SSH_SOCK=$(gpgconf --list-dirs agent-ssh-socket)
-        if [[ -n "$SSH_AUTH_SOCK" && "$SSH_AUTH_SOCK" != "$GPG_AGENT_SSH_SOCK" ]]; then
+	      if [[ -n "$SSH_AUTH_SOCK" && "$SSH_AUTH_SOCK" != "$GPG_AGENT_SSH_SOCK" && $(readlink -f $SSH_AUTH_SOCK) != $GPG_AGENT_SSH_SOCK ]]; then
           # use ssh signing with the provided key
           export GIT_CONFIG_COUNT=3
           export GIT_CONFIG_KEY_0=gpg.format


### PR DESCRIPTION
TL;DR
-----

Updates conditional that guard the git configs for Yubikey vs. Secure
Enclave SSH keys

Details
-------

I've been playing with the conditional I use to change my git signing
configuration based on whether I'm using Yubikey or Secure Enclave
quite a bit. I was missing a case were I might start a new session
using `smug-session` and not catch I was using GPG.

This version reads a symlinked `SSH_AUTH_SOCK` and checks if it it's
the GPG agent socket instead of just checking if it is set to the GPG
agent auth socket directly.
