### PR TITLE
Includes desktop module in full profile

### DIFF
--- a/home/profiles/full.nix
+++ b/home/profiles/full.nix
@@ -2,6 +2,7 @@
   # Full workstation profile with all modules
   imports = [
     ../modules/base
+    ../modules/desktop
     ../modules/development
     ../modules/editor
     ../modules/go


### PR DESCRIPTION
TL;DR
-----

Makes sure the "full" profile includes the desktop module

Details
-------

Yet another PR of a piece with #164 and #165. Assure a home environmment
with the "full" profile includes the "desktop" home module. Should have
been included in #161.
