### PR TITLE
Fixes exa-py build

### DIFF
--- a/pkgs/exa-py/default.nix
+++ b/pkgs/exa-py/default.nix
@@ -8,6 +8,12 @@
 python3.pkgs.buildPythonPackage rec {
   pname = "exa-py";
   version = "1.14.6";
+
+
+  pyproject = true;
+  build-system = [ 
+    python3.pkgs.setuptools
+  ];
   
   src = fetchFromGitHub {
     owner = "exa-labs";


### PR DESCRIPTION
TL;DR
-----

Corrects the exa-py package build by specifying PyProject-based build configuration

Details
--------

Follows best practice by adding the `pyproject = true` flag and declaring setuptools as the build system. This approach provides more deterministic builds, better dependency resolution, and compatibility with modern Python tooling.

The change is minimal but impactful, as it helps maintain the package's long-term viability in the evolving Python ecosystem without requiring significant code modifications.
