### PR TITLE
Shows Neotree for new (Neo)Vim(R) tabs

### DIFF
--- a/home/modules/editor/default.nix
+++ b/home/modules/editor/default.nix
@@ -74,6 +74,12 @@ in {
           end
         })
         
+        vim.api.nvim_create_autocmd("TabNewEntered", {
+          callback = function()
+            vim.cmd("Neotree show")
+          end,
+        })
+
         vim.api.nvim_set_keymap("n", "<C-P>", ":Files<CR>", { noremap = true })
         
         -- Supermaven setup


### PR DESCRIPTION
TL;DR
-----

Enhances my workflow by automatically displaying the Neo-tree
file explorer whenever a new tab is created in Neovim.

Details
--------

Addresses a user experience inconsistency in the current tab
workflow. Previously, when opening a new tab in Neovim, users had to
manually invoke Neo-tree to see the file explorer, breaking their
context and requiring additional keystrokes.

The implementation creates an autocmd that hooks into the
`TabNewEntered` event, automatically displaying the Neo-tree file
explorer whenever a new tab is created. This maintains consistency with
the expected editor state and provides immediate access to the file
navigation interface without manual intervention.

The change aligns with the existing editor configuration philosophy
where Neo-tree is treated as a core navigation component rather than an
occasional tool, making the tab-based workflow more efficient and
predictable for regular users.
