### PR TITLE
Improve SSH configuration for homelab servers

### DIFF
--- a/home/modules/homelab/config/ssh/config.d/jumpbox
+++ b/home/modules/homelab/config/ssh/config.d/jumpbox
@@ -1,23 +1,23 @@
 Match exec "[[ $(uname) == 'Darwin' ]]" host mash
   CanonicalizeHostName yes
-  CanonicalDomains shortrib.sh walrus-shark.ts.net lab.shortrib.net 
+  CanonicalDomains lab.shortrib.net shortrib.sh 
   StreamLocalBindUnlink yes
   RemoteForward /run/user/1001/gnupg/S.gpg-agent %d/.gnupg/S.gpg-agent
   RemoteForward /run/user/1001/gnupg/S.gpg-agent.ssh %d/.gnupg/S.gpg-agent.ssh
 
 Match exec "[[ $(uname) == 'Darwin' ]]" host pisco
   CanonicalizeHostName yes
-  CanonicalDomains shortrib.sh walrus-shark.ts.net lab.shortrib.net 
+  CanonicalDomains lab.shortrib.net shortrib.sh 
   StreamLocalBindUnlink yes
-  RemoteForward %d/.gnupg/S.gpg-agent %d/.gnupg/S.gpg-agent
-  RemoteForward %d/.gnupg/S.gpg-agent.ssh %d/.gnupg/S.gpg-agent.ssh
+  RemoteForward /Users/crdant/.gnupg/S.gpg-agent %d/.gnupg/S.gpg-agent
+  RemoteForward /Users/crdant/.gnupg/S.gpg-agent.ssh %d/.gnupg/S.gpg-agent.ssh
 
 Match exec "[[ $(uname) == 'Darwin' ]]" host fullscreen
   RemoteCommand source ~/.zshrc && fullscreen
   RequestTTY Yes
   HostName mash
   CanonicalizeHostName yes
-  CanonicalDomains shortrib.sh walrus-shark.ts.net lab.shortrib.net 
+  CanonicalDomains lab.shortrib.net shortrib.sh 
   StreamLocalBindUnlink yes
   RemoteForward /run/user/1001/gnupg/S.gpg-agent %d/..gnupg/S.gpg-agent.extra 
   RemoteForward /run/user/1001/gnupg/S.gpg-agent.ssh %d/.gnupg/S.gpg-agent.ssh
@@ -27,7 +27,7 @@ Match exec "[[ $(uname) == 'Darwin' ]]" host window
   RequestTTY Yes
   HostName mash
   CanonicalizeHostName yes
-  CanonicalDomains shortrib.sh walrus-shark.ts.net lab.shortrib.net 
+  CanonicalDomains lab.shortrib.net shortrib.sh 
   StreamLocalBindUnlink yes
   RemoteForward /run/user/1001/gnupg/S.gpg-agent %d/.gnupg/S.gpg-agent.extra 
   RemoteForward /run/user/1001/gnupg/S.gpg-agent.ssh %d/.gnupg/S.gpg-agent.ssh

--- a/home/modules/homelab/config/ssh/config.d/projects
+++ b/home/modules/homelab/config/ssh/config.d/projects
@@ -3,7 +3,7 @@ Match exec "[[ $(uname) == 'Darwin' ]]" host *.mash
   RequestTTY Yes
   HostName mash
   CanonicalizeHostName yes
-  CanonicalDomains walrus-shark.ts.net lab.shortrib.net 
+  CanonicalDomains lab.shortrib.net shortrib.sh 
   StreamLocalBindUnlink yes
   RemoteForward /run/user/1001/gnupg/S.gpg-agent %d/.gnupg/S.gpg-agent.extra 
   RemoteForward /run/user/1001/gnupg/S.gpg-agent.ssh %d/.gnupg/S.gpg-agent.ssh
@@ -11,9 +11,9 @@ Match exec "[[ $(uname) == 'Darwin' ]]" host *.mash
 Match exec "[[ $(uname) == 'Darwin' ]]" host *.pisco
   RemoteCommand source ~/.zshrc && cd ~/workspace/$(basename %n .pisco) && smug-session window
   RequestTTY Yes
-  HostName mash
+  HostName pisco
   CanonicalizeHostName yes
-  CanonicalDomains walrus-shark.ts.net lab.shortrib.net 
+  CanonicalDomains lab.shortrib.net shortrib.sh 
   StreamLocalBindUnlink yes
-  RemoteForward %d/.gnupg/S.gpg-agent %d/.gnupg/S.gpg-agent
-  RemoteForward %d/.gnupg/S.gpg-agent.ssh %d/.gnupg/S.gpg-agent.ssh
+  RemoteForward /Users/crdant/.gnupg/S.gpg-agent %d/.gnupg/S.gpg-agent
+  RemoteForward /Users/crdant/.gnupg/S.gpg-agent.ssh %d/.gnupg/S.gpg-agent.ssh


### PR DESCRIPTION
TL;DR
-----

Optimizes SSH configuration for homelab servers by prioritizing the lab
domain, fixing incorrect host paths, and ensuring proper GPG agent
forwarding.

Details
--------

Improves the reliability and security of SSH connections to the homelab
environment. It makes three key improvements to the existing
configuration:

1. Reorders canonical domain priorities to prefer `lab.shortrib.net`
   over other domains, which provides more consistent and reliable
   hostname resolution within the lab environment.

2. Removes the no-longer-used Tailscale domain (`walrus-shark.ts.net`)
   from all host configurations, streamlining the connection process and
   removing potential confusion when connecting to hosts.

3. Fixes critical path issues in the GPG agent forwarding configuration
   for the `pisco` host:
   - Replaces generic path placeholders with explicit paths
   - Corrects an incorrect hostname reference that was causing
     connections to route through the wrong server
   - Ensures consistent socket forwarding behavior across all host
     configurations

These adjustments make remote development sessions more reliable while
maintaining the security benefits of GPG agent forwarding for
authentication. The configuration now properly distinguishes between
different host environments and provides the correct forwarding paths
for each specific use case.
