### PR TITLE
Uses Nix Ghostty and adds more terminfos

### DIFF
--- a/systems/modules/base/default.nix
+++ b/systems/modules/base/default.nix
@@ -12,6 +12,10 @@ in {
     stateVersion
   ];
 
+  imports = [
+    ./terminfo.nix
+  ];
+
   # assure flakes and nix command are enabled
   nix = {
     extraOptions = ''
@@ -81,6 +85,8 @@ in {
   # bash is enabled by default
 
   environment = {
+    enableAllTerminfo = true;
+
     systemPackages = with pkgs; [
       coreutils
       glow

--- a/systems/modules/desktop/default.nix
+++ b/systems/modules/desktop/default.nix
@@ -27,7 +27,6 @@ let
       casks = [
         "font-cabin"
         "font-noto-sans"
-        "ghostty@tip"
         "google-drive"
         "hammerspoon"
         "noun-project"
@@ -68,6 +67,7 @@ in (lib.mkMerge [
       systemPackages = with pkgs; lib.optionals isDarwin [
         espanso
         firefox
+        ghostty
         google-chrome
         open-sans
         slack


### PR DESCRIPTION
TL;DR
-----

Implements proper terminfo database support and migrates the Ghostty
terminal from Homebrew to Nix for consistent package management.

Details
--------

Improves terminal compatibility across the system by enabling the full
terminfo database and properly organizing terminal-related
configurations. The main improvements include:

1. Backports terminfo handling from Nix-Darwin 25.11 and enables it
2. Moves Ghostty terminal from Homebrew casks to Nix packages for
   better integration

This approach creates a more maintainable system by centralizing
terminal support in Nix rather than splitting it between package
managers, while ensuring proper terminal capabilities are available
throughout the environment.
