### PR TITLE
Install xcodegen from Homebrew instead of nixpkgs

### DIFF
--- a/home/modules/swift/default.nix
+++ b/home/modules/swift/default.nix
@@ -12,7 +12,8 @@ in {
     swiftlint
     terminal-notifier
     xcbeautify
-    unstable.xcodegen
+    # avoid rabbit hole with swift versions
+    # xcodegen
   ];
 
   programs = {

--- a/home/users/crdant/darwin.nix
+++ b/home/users/crdant/darwin.nix
@@ -21,6 +21,7 @@ in
     brews = [
       "swiftformat"
       "xcode-build-server"
+      "xcodegen"
     ];
     casks = [
       "claude"


### PR DESCRIPTION
TL;DR
-----

Resolves Swift version challenges by installing xcodegen through
Homebrew instead of the unstable nixpkgs channel.

Details
--------

Moves xcodegen installation to Homebrew where it is more up-to-date
than the unstable nixpkgs channel. This avoids chasing down a bunch of
compatibility issues between the Switft version used in the current
version and what's available in Nix packages.
