### PR TITLE
Reverts to installing Ghostty with Homebrew

### DIFF
--- a/systems/modules/desktop/default.nix
+++ b/systems/modules/desktop/default.nix
@@ -27,6 +27,7 @@ let
       casks = [
         "font-cabin"
         "font-noto-sans"
+        "ghostty@tip"
         "google-drive"
         "hammerspoon"
         "noun-project"
@@ -67,7 +68,6 @@ in (lib.mkMerge [
       systemPackages = with pkgs; lib.optionals isDarwin [
         espanso
         firefox
-        ghostty
         google-chrome
         open-sans
         slack


### PR DESCRIPTION
TL;DR
-----

Avoids Zig compilation issues on Darwin by using Homebrew for Ghostty

Details
-------

Shifts back to using Homebrew to install Ghostty tip. The current
version of the Nix pacakge doesn't compile correctly on Darwin.
