### PR TITLE
Includes Nix User Repositories

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -42,6 +42,27 @@
         "type": "github"
       }
     },
+    "flake-parts": {
+      "inputs": {
+        "nixpkgs-lib": [
+          "nur",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1733312601,
+        "narHash": "sha256-4pDvzqnegAfRkPwO3wmwBhVi/Sye1mzps0zHWYnP88c=",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "rev": "205b12d8b7cd4802fbcb8e8ef6a0f1408781a4f9",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "type": "github"
+      }
+    },
     "flake-utils": {
       "inputs": {
         "systems": "systems"
@@ -129,6 +150,27 @@
         "type": "github"
       }
     },
+    "nur": {
+      "inputs": {
+        "flake-parts": "flake-parts",
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1754334112,
+        "narHash": "sha256-AgFtPG69PJzTGWK7SEKu6DTzbDvA2jrZMEcNKWON3qg=",
+        "owner": "nix-community",
+        "repo": "NUR",
+        "rev": "4f3495740e94b46f26224d69c7bca99c4636a9e4",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "NUR",
+        "type": "github"
+      }
+    },
     "root": {
       "inputs": {
         "_1password-shell-plugins": "_1password-shell-plugins",
@@ -136,6 +178,7 @@
         "home-manager": "home-manager",
         "nixpkgs": "nixpkgs",
         "nixpkgs-unstable": "nixpkgs-unstable",
+        "nur": "nur",
         "sops-nix": "sops-nix"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -12,6 +12,11 @@
     darwin.url = "github:lnl7/nix-darwin/nix-darwin-25.05";
     darwin.inputs.nixpkgs.follows = "nixpkgs"; # ...
 
+    nur = {
+      url = "github:nix-community/NUR";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+
     _1password-shell-plugins.url = "github:1Password/shell-plugins";
     _1password-shell-plugins.inputs.nixpkgs.follows = "home-manager"; # ...
 
@@ -23,10 +28,18 @@
       system = builtins.currentSystem;
       isDarwin = nixpkgs.legacyPackages.${system}.stdenv.isDarwin;
       
+      pkgs = import nixpkgs {
+        inherit system;
+        overlays = [
+          inputs.nur.overlays.default
+          inputs.home-manager.overlays.default
+        ];
+      };
+
       # Helper function to create home configurations with profiles
       mkHomeConfig = { username, homeDirectory, gitEmail, profile ? "full" }: 
         home-manager.lib.homeManagerConfiguration {
-          pkgs = nixpkgs.legacyPackages.${system};
+          inherit pkgs;
           extraSpecialArgs = {inherit inputs outputs username homeDirectory gitEmail profile;};
           modules = [ 
             ./home/users/crdant/home.nix
@@ -51,6 +64,7 @@
           system = "aarch64-darwin";
           specialArgs = {inherit inputs outputs;};
           modules = [ 
+            ./systems/modules/base/terminfo.nix
             ./systems/hosts/grappa/default.nix
             ./home/users/crdant/crdant.nix
             ./home/users/crdant/darwin.nix
@@ -61,6 +75,7 @@
           system = "aarch64-darwin";
           specialArgs = {inherit inputs outputs;};
           modules = [ 
+            ./systems/modules/base/terminfo.nix
             ./systems/hosts/sochu/default.nix
             ./home/users/crdant/chuck.nix
             ./home/users/crdant/darwin.nix

--- a/home/modules/base/default.nix
+++ b/home/modules/base/default.nix
@@ -76,6 +76,7 @@ in {
       outputs.overlays.additions
       outputs.overlays.modifications
       outputs.overlays.unstable-packages
+      outputs.overlays.nur-packages
     ];
   };
 

--- a/overlays/default.nix
+++ b/overlays/default.nix
@@ -42,4 +42,11 @@
       config.allowUnfree = true;
     };
   };
+
+  nur-packages = final: prev: {
+    nur = import inputs.nur {
+      pkgs = final;
+      system = final.system;
+    };
+  };
 }

--- a/systems/modules/base/default.nix
+++ b/systems/modules/base/default.nix
@@ -45,6 +45,7 @@ in {
       outputs.overlays.additions
       outputs.overlays.modifications
       outputs.overlays.unstable-packages
+      outputs.overlays.nur-packages
 
       # You can also add overlays exported from other flakes:
       # neovim-nightly-overlay.overlays.default


### PR DESCRIPTION
TL;DR
-----

Incoproates NUR into the flake to start grabbing packages for it

Details
-------

Today I learned about Nix User Repositories (NUR) when looking to
install the `crush` AI coding CLI. This change prepares to install
`crush` by adding NUR to the flake.
