### PR TITLE
Moves sheklcheck install to a better place

### DIFF
--- a/home/modules/development/default.nix
+++ b/home/modules/development/default.nix
@@ -15,6 +15,7 @@ in {
       fermyon-spin
       nix-init
       nix-prefetch-git
+      shellcheck
       subversion
     ] ++ lib.optionals isDarwin [
     ];


### PR DESCRIPTION
TL;DR
-----

Takes shellcheck and moves it to development module

Details
-------

Installs `shcllcheck` as part of the `development` module, since it is,
after all, a development tool. It was being installed in `editor`.
