### PR TITLE
Incliudes Knot DNS utils for Homelab environments

### DIFF
--- a/home/modules/homelab/default.nix
+++ b/home/modules/homelab/default.nix
@@ -7,6 +7,7 @@ in {
   home = {
     packages = with pkgs; [
       govc
+      knot-dns
       minio-client
       powershell
     ] ++ lib.optionals isDarwin [


### PR DESCRIPTION
TL;DR
-----

Updates home environment Homelab module with Knot DNS utils

Details
-------

Adds the Knot DNS utils to the Homelab module in my home environment.
These tools are evolved versions of the core DNS utils like `dig` and
`nsupdate` with some egonomic improvements I'd like to take advantage
of.
