### PR TITLE
Assures that we're using the same GNU make

### DIFF
--- a/home/modules/development/default.nix
+++ b/home/modules/development/default.nix
@@ -7,11 +7,12 @@ in {
   # Development-related packages
   home = {
     packages = with pkgs; [
+      unstable.cue
       exercism
       gh
       git-filter-repo
       git-lfs
-      unstable.cue
+      gnumake
       fermyon-spin
       nix-init
       nix-prefetch-git


### PR DESCRIPTION
TL;DR
-----

Includes newer GNU `make` in the development home environment module

Details
-------

Addresses an issue I've had on some of my Macs where the built in `make`
can't process my `Makefile`s by assuring we always use GNU `make` from
Nix which is newer.
