### PR TITLE
Fixes Ghostty copy on select

### DIFF
--- a/home/modules/desktop/config/ghostty/config
+++ b/home/modules/desktop/config/ghostty/config
@@ -1,5 +1,5 @@
 theme = dark:rose-pine-moon,light:rose-pine-dawn
 font-family = "Inconsolata Regular Regular"
 font-size = 11
-copy-on-select = true
+copy-on-select = clipboard
 keybind = shift+enter=text:\n


### PR DESCRIPTION
TL;DR
-----

Sets the copy on select capability of Ghostty to use the sysetm
clipboard.

Details
-------

Fixes my Ghostty config so that it will use the system clipboard
instead of the select clipboard for copy on select.
