### PR TITLE
Temporarily(?) Comments out incompatible `llm` tool

### DIFF
--- a/overlays/llm/default.nix
+++ b/overlays/llm/default.nix
@@ -120,7 +120,7 @@ let
     llmPlugins.llm-tools-simpleeval
     llmPlugins.llm-tools-quickjs
     llmPlugins.llm-tools-exa
-    llmPlugins.llm-tools-rag
+    # llmPlugins.llm-tools-rag
   ];
 
   # fetch shell completion files from the llm-cmd-comp repository


### PR DESCRIPTION
TL;DR
-----

Avoids issues with install the `llm` CLI by avoiding installing RAG
tool

Details
-------

Skips installing the RAG plugin for the `llm` CLI. The plugin provides
a tool for RAG to the `llm` CLI, but it has a dependency on an older
version of `llm` than the one we're installing. Hopefully, they
matintainer will bump that up and we can install it again soon.
