### PR TITLE
Relocates activation script config

### DIFF
--- a/home/modules/base/default.nix
+++ b/home/modules/base/default.nix
@@ -68,23 +68,24 @@ in {
         recursive = true;
       };
     };
-  };
 
-  activation = {
-   workspaceDirectory = lib.hm.dag.entryBefore [ "writeBoundary" ] ''
-      mkdir -p ~/workspace
-      mkdir -p ~/sandbox
-    '';
+    activation = {
+     workspaceDirectory = lib.hm.dag.entryBefore [ "writeBoundary" ] ''
+        mkdir -p ~/workspace
+        mkdir -p ~/sandbox
+      '';
 
-    customizeOmz = lib.hm.dag.entryAfter [ "writeBoundary" "installPackages" "git" ] ''
-      if [ ! -d ~/workspace/oh-my-zsh-custom ]; then
-        ${pkgs.git}/bin/git clone https://github.com/crdant/oh-my-zsh-custom ~/workspace/oh-my-zsh-custom || {
-          echo "Warning: Failed to clone oh-my-zsh-custom repository. Skipping..."
-        }
-      else
-        echo "oh-my-zsh-custom already exists, skipping clone"
-      fi
-    '';
+      customizeOmz = lib.hm.dag.entryAfter [ "writeBoundary" "installPackages" "git" ] ''
+        if [ ! -d ~/workspace/oh-my-zsh-custom ]; then
+          ${pkgs.git}/bin/git clone https://github.com/crdant/oh-my-zsh-custom ~/workspace/oh-my-zsh-custom || {
+            echo "Warning: Failed to clone oh-my-zsh-custom repository. Skipping..."
+          }
+        else
+          echo "oh-my-zsh-custom already exists, skipping clone"
+        fi
+      '';
+    };
+
   };
 
   nixpkgs = {


### PR DESCRIPTION
TL;DR
-----

Fixes defect where activation script is defined at the wrong place

Details
-------

Corrects the base home environment module to included that activation
script in the home configuration where it belongs. It was previously
at the same level as the `home` config, but it's supposed to be part
of it.
