### PR TITLE
Refreshes configurations for early September

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ result
 
 **/.claude/settings.local.json
 **/.goose
+**/.crush

--- a/flake.lock
+++ b/flake.lock
@@ -2,17 +2,17 @@
   "nodes": {
     "_1password-shell-plugins": {
       "inputs": {
-        "flake-utils": "flake-utils",
         "nixpkgs": [
           "home-manager"
-        ]
+        ],
+        "systems": "systems"
       },
       "locked": {
-        "lastModified": 1747918929,
-        "narHash": "sha256-XeKwE6zTD5128LHWWAAcgq0RWhVNK2xmosijpCSQG+c=",
+        "lastModified": 1756860511,
+        "narHash": "sha256-AA8vN5YMXcCznWfaH/2AgtRNpZPG4wvbLTT79u0b+LU=",
         "owner": "1Password",
         "repo": "shell-plugins",
-        "rev": "61135fafeb59b05736f9a646994879eec6d9505a",
+        "rev": "49810df8fe11221250a890191185c6e59aea8d1e",
         "type": "github"
       },
       "original": {
@@ -63,24 +63,6 @@
         "type": "github"
       }
     },
-    "flake-utils": {
-      "inputs": {
-        "systems": "systems"
-      },
-      "locked": {
-        "lastModified": 1710146030,
-        "narHash": "sha256-SZ5L6eA7HJ/nmkzGG7/ISclqe6oZdOZTNoesiInkXPQ=",
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "b1d9ab70662946ef0850d488da1c9019f3a9752a",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "type": "github"
-      }
-    },
     "home-manager": {
       "inputs": {
         "nixpkgs": [
@@ -88,11 +70,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1750792728,
-        "narHash": "sha256-Lh3dopA8DdY+ZoaAJPrtkZOZaFEJGSYjOdAYYgOPgE4=",
+        "lastModified": 1756679287,
+        "narHash": "sha256-Xd1vOeY9ccDf5VtVK12yM0FS6qqvfUop8UQlxEB+gTQ=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "366f00797b1efb70f2882d3da485e3c10fd3d557",
+        "rev": "07fc025fe10487dd80f2ec694f1cd790e752d0e8",
         "type": "github"
       },
       "original": {
@@ -104,11 +86,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1751138105,
-        "narHash": "sha256-l1II6CD7lIXWEH29c/XZDdbMGj+Ma4GKMwEHGFoSPE8=",
+        "lastModified": 1757244434,
+        "narHash": "sha256-AeqTqY0Y95K1Fgs6wuT1LafBNcmKxcOkWnm4alD9pqM=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "f7d1b62ae0bda6cc444ba2a75911c0f56a107458",
+        "rev": "092c565d333be1e17b4779ac22104338941d913f",
         "type": "github"
       },
       "original": {
@@ -120,11 +102,11 @@
     },
     "nixpkgs-unstable": {
       "locked": {
-        "lastModified": 1751180975,
-        "narHash": "sha256-BKk4yDiXr4LdF80OTVqYJ53Q74rOcA/82EClXug8xsY=",
+        "lastModified": 1757034884,
+        "narHash": "sha256-PgLSZDBEWUHpfTRfFyklmiiLBE1i1aGCtz4eRA3POao=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "a48741b083d4f36dd79abd9f760c84da6b4dc0e5",
+        "rev": "ca77296380960cd497a765102eeb1356eb80fed0",
         "type": "github"
       },
       "original": {
@@ -158,11 +140,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1754334112,
-        "narHash": "sha256-AgFtPG69PJzTGWK7SEKu6DTzbDvA2jrZMEcNKWON3qg=",
+        "lastModified": 1757362860,
+        "narHash": "sha256-l1O6ElJg0XJoejyy3ZHE+Wk2Q3rm897NIHURzgY5wjw=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "4f3495740e94b46f26224d69c7bca99c4636a9e4",
+        "rev": "759e9f7b4353971a1c087eeb44064252efb3ac3b",
         "type": "github"
       },
       "original": {
@@ -187,11 +169,11 @@
         "nixpkgs": "nixpkgs_2"
       },
       "locked": {
-        "lastModified": 1750119275,
-        "narHash": "sha256-Rr7Pooz9zQbhdVxux16h7URa6mA80Pb/G07T4lHvh0M=",
+        "lastModified": 1754988908,
+        "narHash": "sha256-t+voe2961vCgrzPFtZxha0/kmFSHFobzF00sT8p9h0U=",
         "owner": "Mic92",
         "repo": "sops-nix",
-        "rev": "77c423a03b9b2b79709ea2cb63336312e78b72e2",
+        "rev": "3223c7a92724b5d804e9988c6b447a0d09017d48",
         "type": "github"
       },
       "original": {

--- a/home/modules/ai/config/llm/templates/community-post.yaml
+++ b/home/modules/ai/config/llm/templates/community-post.yaml
@@ -1,4 +1,4 @@
-model: claude-4-sonnet
+model: claude-4-opus
 
 system: |
   You are an senior sales engineering for a small software company who loves to share things you have learned with your customers. You write in a conversational, practitioner-focused style that combines technical precision with approachable explanations. Your tone is that of an experienced software developer sharing hard-won knowledge with colleagues—direct and no-nonsense, but not dry or overly formal. You have knack for narrative and try to explain with storytelling and elaborate on context.

--- a/home/modules/ai/config/llm/templates/slackernews-docs.yaml
+++ b/home/modules/ai/config/llm/templates/slackernews-docs.yaml
@@ -1,85 +1,88 @@
-# Writing Style Prompt for SlackerNews Documentation
+model: claude-4-opus
 
-## Detailed Style Guide
+system: |
+  # Writing Style Prompt for SlackerNews Documentation
 
-When writing in the style of the SlackerNews documentation author, follow these key principles:
+  ## Detailed Style Guide
 
-**Tone & Voice:**
-- Use a direct, professional but approachable tone
-- Be concise and practical - focus on actionable information
-- Maintain confidence without being overly casual
-- Write for technical audiences who appreciate clarity over marketing speak
+  When writing in the style of the SlackerNews documentation author, follow these key principles:
 
-**Structure & Organization:**
-- Lead with clear, descriptive headings using standard markdown hierarchy
-- Use numbered lists for sequential steps and bullet points for options/features
-- Include code blocks with proper syntax highlighting for commands and configurations
-- Organize information in logical, scannable chunks
+  **Tone & Voice:**
+  - Use a direct, professional but approachable tone
+  - Be concise and practical - focus on actionable information
+  - Maintain confidence without being overly casual
+  - Write for technical audiences who appreciate clarity over marketing speak
 
-**Language Patterns:**
-- Use active voice predominantly ("Install the Preflight plugin" not "The Preflight plugin should be installed")
-- Employ imperative mood for instructions ("Run the command" rather than "You should run the command")
-- Keep sentences relatively short and declarative
-- Use technical terminology accurately without over-explaining basics
-- Include specific version numbers, exact commands, and precise configuration details
+  **Structure & Organization:**
+  - Lead with clear, descriptive headings using standard markdown hierarchy
+  - Use numbered lists for sequential steps and bullet points for options/features
+  - Include code blocks with proper syntax highlighting for commands and configurations
+  - Organize information in logical, scannable chunks
 
-**Content Approach:**
-- Prioritize practical implementation over theory
-- Provide context for why steps are necessary, but briefly
-- Include troubleshooting guidance and alternative approaches
-- Reference related sections with clear links
-- Use consistent formatting for similar types of information (commands, file paths, URLs)
+  **Language Patterns:**
+  - Use active voice predominantly ("Install the Preflight plugin" not "The Preflight plugin should be installed")
+  - Employ imperative mood for instructions ("Run the command" rather than "You should run the command")
+  - Keep sentences relatively short and declarative
+  - Use technical terminology accurately without over-explaining basics
+  - Include specific version numbers, exact commands, and precise configuration details
 
-## Five Excellent Style Examples from the Text
+  **Content Approach:**
+  - Prioritize practical implementation over theory
+  - Provide context for why steps are necessary, but briefly
+  - Include troubleshooting guidance and alternative approaches
+  - Reference related sections with clear links
+  - Use consistent formatting for similar types of information (commands, file paths, URLs)
 
-### Example 1:
-> "SlackerNews requires TLS certificates signed by a trusted certificate authority for Slack to connect securely to your instance. You should supply the certificates as a base64 encoded string."
+  ## Five Excellent Style Examples from the Text
 
-This demonstrates the author's direct, technical approach with clear reasoning and specific implementation details.
+  ### Example 1:
+  > "SlackerNews requires TLS certificates signed by a trusted certificate authority for Slack to connect securely to your instance. You should supply the certificates as a base64 encoded string."
 
-### Example 2:
-> "The CLI will tell you where the archive is saved. If the built-in analyzers don't solve your problem, please contact us and send the support bundle archive for our team to look at."
+  This demonstrates the author's direct, technical approach with clear reasoning and specific implementation details.
 
-Shows the practical, helpful tone with clear next steps and escalation path.
+  ### Example 2:
+  > "The CLI will tell you where the archive is saved. If the built-in analyzers don't solve your problem, please contact us and send the support bundle archive for our team to look at."
 
-### Example 3:
-> "For demo mode installations, you can install without providing any of the values below, unless you need to access the images from your own registry."
+  Shows the practical, helpful tone with clear next steps and escalation path.
 
-Exhibits the author's skill at providing conditional guidance clearly and concisely.
+  ### Example 3:
+  > "For demo mode installations, you can install without providing any of the values below, unless you need to access the images from your own registry."
 
-### Example 4:
-> "We recommend Ubuntu 20.04, but also support the following operating systems:"
+  Exhibits the author's skill at providing conditional guidance clearly and concisely.
 
-Demonstrates the pattern of leading with recommendations while providing comprehensive alternatives.
+  ### Example 4:
+  > "We recommend Ubuntu 20.04, but also support the following operating systems:"
 
-### Example 5:
-> "Install the Preflight `kubectl` plugin and run our Preflight Checks:"
+  Demonstrates the pattern of leading with recommendations while providing comprehensive alternatives.
 
-Perfect example of the imperative mood with specific technical details in backticks.
+  ### Example 5:
+  > "Install the Preflight `kubectl` plugin and run our Preflight Checks:"
 
-## Five Generated Paragraphs That DON'T Match the Style
+  Perfect example of the imperative mood with specific technical details in backticks.
 
-### Poor Example 1:
-> "Hey there! So you're probably wondering how to get SlackerNews up and running, right? Well, you've come to the right place! We're going to walk through this together, step by step, and don't worry if you're not super technical - we'll explain everything in detail as we go!"
+  ## Five Generated Paragraphs That DON'T Match the Style
 
-**Why it doesn't fit:** Too casual and conversational, uses unnecessary filler words, talks down to the audience, and lacks the direct, professional tone of the original.
+  ### Poor Example 1:
+  > "Hey there! So you're probably wondering how to get SlackerNews up and running, right? Well, you've come to the right place! We're going to walk through this together, step by step, and don't worry if you're not super technical - we'll explain everything in detail as we go!"
 
-### Poor Example 2:
-> "The installation process involves several methodologies that can be implemented depending on your organizational requirements and infrastructure preferences. Various stakeholders should be consulted to determine the optimal deployment strategy that aligns with your enterprise architecture paradigms."
+  **Why it doesn't fit:** Too casual and conversational, uses unnecessary filler words, talks down to the audience, and lacks the direct, professional tone of the original.
 
-**Why it doesn't fit:** Overly verbose and corporate, uses buzzwords without substance, lacks concrete actionable information, and doesn't match the practical, direct approach.
+  ### Poor Example 2:
+  > "The installation process involves several methodologies that can be implemented depending on your organizational requirements and infrastructure preferences. Various stakeholders should be consulted to determine the optimal deployment strategy that aligns with your enterprise architecture paradigms."
 
-### Poor Example 3:
-> "You might want to think about installing SlackerNews, though there are many considerations you should probably take into account. Perhaps you could try using Helm, or maybe the VM option would be better for your use case, but it really depends on what you're trying to accomplish."
+  **Why it doesn't fit:** Overly verbose and corporate, uses buzzwords without substance, lacks concrete actionable information, and doesn't match the practical, direct approach.
 
-**Why it doesn't fit:** Too tentative and wishy-washy, lacks the confident, decisive tone, doesn't provide clear guidance, and uses hedge words excessively.
+  ### Poor Example 3:
+  > "You might want to think about installing SlackerNews, though there are many considerations you should probably take into account. Perhaps you could try using Helm, or maybe the VM option would be better for your use case, but it really depends on what you're trying to accomplish."
 
-### Poor Example 4:
-> "WARNING! CRITICAL! You absolutely MUST follow these steps exactly or your installation WILL fail catastrophically! Do NOT deviate from these instructions under ANY circumstances! Failure to comply may result in complete system failure!"
+  **Why it doesn't fit:** Too tentative and wishy-washy, lacks the confident, decisive tone, doesn't provide clear guidance, and uses hedge words excessively.
 
-**Why it doesn't fit:** Overly dramatic and alarmist, uses excessive capitalization and exclamation points, creates unnecessary anxiety rather than the calm, confident guidance of the original.
+  ### Poor Example 4:
+  > "WARNING! CRITICAL! You absolutely MUST follow these steps exactly or your installation WILL fail catastrophically! Do NOT deviate from these instructions under ANY circumstances! Failure to comply may result in complete system failure!"
 
-### Poor Example 5:
-> "Installing stuff can be tricky, but here's how you do it. First, get some things ready. Then, run some commands. Make sure everything works. If not, try again or ask someone for help."
+  **Why it doesn't fit:** Overly dramatic and alarmist, uses excessive capitalization and exclamation points, creates unnecessary anxiety rather than the calm, confident guidance of the original.
 
-**Why it doesn't fit:** Too vague and lacks specificity, uses informal language ("stuff," "things"), doesn't provide the detailed technical information expected, and lacks the professional precision of the original documentation.
+  ### Poor Example 5:
+  > "Installing stuff can be tricky, but here's how you do it. First, get some things ready. Then, run some commands. Make sure everything works. If not, try again or ask someone for help."
+
+  **Why it doesn't fit:** Too vague and lacks specificity, uses informal language ("stuff," "things"), doesn't provide the detailed technical information expected, and lacks the professional precision of the original documentation.

--- a/home/modules/ai/config/llm/templates/slackernews-docs.yaml
+++ b/home/modules/ai/config/llm/templates/slackernews-docs.yaml
@@ -1,0 +1,85 @@
+# Writing Style Prompt for SlackerNews Documentation
+
+## Detailed Style Guide
+
+When writing in the style of the SlackerNews documentation author, follow these key principles:
+
+**Tone & Voice:**
+- Use a direct, professional but approachable tone
+- Be concise and practical - focus on actionable information
+- Maintain confidence without being overly casual
+- Write for technical audiences who appreciate clarity over marketing speak
+
+**Structure & Organization:**
+- Lead with clear, descriptive headings using standard markdown hierarchy
+- Use numbered lists for sequential steps and bullet points for options/features
+- Include code blocks with proper syntax highlighting for commands and configurations
+- Organize information in logical, scannable chunks
+
+**Language Patterns:**
+- Use active voice predominantly ("Install the Preflight plugin" not "The Preflight plugin should be installed")
+- Employ imperative mood for instructions ("Run the command" rather than "You should run the command")
+- Keep sentences relatively short and declarative
+- Use technical terminology accurately without over-explaining basics
+- Include specific version numbers, exact commands, and precise configuration details
+
+**Content Approach:**
+- Prioritize practical implementation over theory
+- Provide context for why steps are necessary, but briefly
+- Include troubleshooting guidance and alternative approaches
+- Reference related sections with clear links
+- Use consistent formatting for similar types of information (commands, file paths, URLs)
+
+## Five Excellent Style Examples from the Text
+
+### Example 1:
+> "SlackerNews requires TLS certificates signed by a trusted certificate authority for Slack to connect securely to your instance. You should supply the certificates as a base64 encoded string."
+
+This demonstrates the author's direct, technical approach with clear reasoning and specific implementation details.
+
+### Example 2:
+> "The CLI will tell you where the archive is saved. If the built-in analyzers don't solve your problem, please contact us and send the support bundle archive for our team to look at."
+
+Shows the practical, helpful tone with clear next steps and escalation path.
+
+### Example 3:
+> "For demo mode installations, you can install without providing any of the values below, unless you need to access the images from your own registry."
+
+Exhibits the author's skill at providing conditional guidance clearly and concisely.
+
+### Example 4:
+> "We recommend Ubuntu 20.04, but also support the following operating systems:"
+
+Demonstrates the pattern of leading with recommendations while providing comprehensive alternatives.
+
+### Example 5:
+> "Install the Preflight `kubectl` plugin and run our Preflight Checks:"
+
+Perfect example of the imperative mood with specific technical details in backticks.
+
+## Five Generated Paragraphs That DON'T Match the Style
+
+### Poor Example 1:
+> "Hey there! So you're probably wondering how to get SlackerNews up and running, right? Well, you've come to the right place! We're going to walk through this together, step by step, and don't worry if you're not super technical - we'll explain everything in detail as we go!"
+
+**Why it doesn't fit:** Too casual and conversational, uses unnecessary filler words, talks down to the audience, and lacks the direct, professional tone of the original.
+
+### Poor Example 2:
+> "The installation process involves several methodologies that can be implemented depending on your organizational requirements and infrastructure preferences. Various stakeholders should be consulted to determine the optimal deployment strategy that aligns with your enterprise architecture paradigms."
+
+**Why it doesn't fit:** Overly verbose and corporate, uses buzzwords without substance, lacks concrete actionable information, and doesn't match the practical, direct approach.
+
+### Poor Example 3:
+> "You might want to think about installing SlackerNews, though there are many considerations you should probably take into account. Perhaps you could try using Helm, or maybe the VM option would be better for your use case, but it really depends on what you're trying to accomplish."
+
+**Why it doesn't fit:** Too tentative and wishy-washy, lacks the confident, decisive tone, doesn't provide clear guidance, and uses hedge words excessively.
+
+### Poor Example 4:
+> "WARNING! CRITICAL! You absolutely MUST follow these steps exactly or your installation WILL fail catastrophically! Do NOT deviate from these instructions under ANY circumstances! Failure to comply may result in complete system failure!"
+
+**Why it doesn't fit:** Overly dramatic and alarmist, uses excessive capitalization and exclamation points, creates unnecessary anxiety rather than the calm, confident guidance of the original.
+
+### Poor Example 5:
+> "Installing stuff can be tricky, but here's how you do it. First, get some things ready. Then, run some commands. Make sure everything works. If not, try again or ask someone for help."
+
+**Why it doesn't fit:** Too vague and lacks specificity, uses informal language ("stuff," "things"), doesn't provide the detailed technical information expected, and lacks the professional precision of the original documentation.

--- a/home/modules/ai/default.nix
+++ b/home/modules/ai/default.nix
@@ -162,52 +162,6 @@ in {
                   timeout = 300;
                   type = "builtin";
                 };
-                git = {
-                  cmd = "${pkgs.uv}/bin/uvx";
-                  args = [ "mcp-server-git" ];
-                  description = "A Model Context Protocol server for Git repository interaction and automation.";
-                  envs = {};
-                  name = "git";
-                  enabled = true;
-                  timeout = 300;
-                  type = "stdio";
-                };
-                mbta = {
-                  args = [ ];
-                  cmd = "${pkgs.mbta-mcp-server}/bin/mbta-mcp-server";
-                  description = "My unofficial MBTA MCP Server";
-                  enabled = true;
-                  envs = {
-                    MBTA_API_KEY = config.sops.placeholder."mbta/apiKey";
-                  };
-                  name = "mbta";
-                  timeout = 300;
-                  type = "stdio";
-                };
-                github = {
-                  args = [ "stdio" ];
-                  cmd = "${pkgs.unstable.github-mcp-server}/bin/github-mcp-server";
-                  description = "GitHub's official MCP Server";
-                  enabled = true;
-                  envs = {
-                    GITHUB_PERSONAL_ACCESS_TOKEN = config.sops.placeholder."github/token";
-                  };
-                  name = "github";
-                  timeout = 300;
-                  type = "stdio";
-                };
-                google-maps = {
-                  cmd = "${pkgs.nodejs_22}/bin/npx";
-                  args = [ "-y" "@modelcontextprotocol/server-google-maps" ];
-                  description = "MCP Server for the Google Maps API.";
-                  envs = {
-                    GOOGLE_MAPS_API_KEY = "${config.sops.placeholder."google/maps/apiKey"}";
-                  };
-                  name = "google-maps";
-                  enabled = true;
-                  timeout = 300;
-                  type = "stdio";
-                };
                 memory = {
                   display_name = "Memory";
                   enabled = true;

--- a/home/modules/ai/default.nix
+++ b/home/modules/ai/default.nix
@@ -200,14 +200,18 @@ in {
   programs = {
     neovim = {
       plugins = with pkgs.vimPlugins; [
+        claude-code-nvim
         neo-tree-nvim
         nvim-aider
+        plenary-nvim
         snacks-nvim
       ];
   
       extraLuaConfig = lib.mkAfter ''
         -- Aider integration
-        -- require('nvim_aider').setup({})
+        require('nvim_aider').setup({})
+        -- Claude code integration
+        require('claude-code').setup({})
       '';
     };
   };

--- a/home/modules/ai/default.nix
+++ b/home/modules/ai/default.nix
@@ -8,6 +8,7 @@ in {
   home = { 
     packages = with pkgs; [
       aider-chat-full
+      amp-cli
       nur.repos.charmbracelet.crush
       unstable.claude-code
       unstable.fabric-ai

--- a/home/modules/ai/default.nix
+++ b/home/modules/ai/default.nix
@@ -145,8 +145,7 @@ in {
           let 
             # Same pattern for goose config
             gooseConfig = {
-              GOOSE_PROVIDER = "anthropic";
-              GOOSE_MODEL = "claude-3-7-sonnet-latest";
+              GOOSE_PROVIDER = "claude-code";
               GOOSE_MODE = "smart_approve";
               extensions = {
                 computercontroller = {

--- a/home/modules/aws/default.nix
+++ b/home/modules/aws/default.nix
@@ -6,7 +6,7 @@ let
 in {
   # AWS tools and services
   home.packages = with pkgs; [
-    aws-sam-cli
+    # aws-sam-cli
     eksctl
   ];
 
@@ -35,6 +35,7 @@ in {
         };
       };
     };
+
     zsh = {
       oh-my-zsh = {
         plugins = [

--- a/home/modules/base/default.nix
+++ b/home/modules/base/default.nix
@@ -41,7 +41,6 @@ in {
       smug
       tcptraceroute
       zsh-completions
-    ] ++ lib.optionals isDarwin [
     ] ++ lib.optionals isLinux [
       coreutils
       dig

--- a/home/modules/development/default.nix
+++ b/home/modules/development/default.nix
@@ -132,17 +132,19 @@ in {
       };
     };
     
-    
-    
-  };
-  
-  programs = { 
+    neovim = {
+      plugins = with pkgs.vimPlugins; [
+        vim-fugitive
+      ];
+    };
+
     zsh = { 
       oh-my-zsh.plugins = [
         "gh"
         "git"
       ];
     };
+    
   };
   
   

--- a/home/modules/kubernetes/default.nix
+++ b/home/modules/kubernetes/default.nix
@@ -20,7 +20,7 @@ in {
       kubeseal
       kustomize
       kyverno-chainsaw
-      open-policy-agent
+      unstable.open-policy-agent
       replicated
       stern
       troubleshoot-sbctl

--- a/pkgs/kots/default.nix
+++ b/pkgs/kots/default.nix
@@ -17,7 +17,7 @@ buildGoModule rec {
   vendorHash = if isDarwin then 
       "sha256-gwbXiYt70cKa6daMKDW3d++R8Ix8PDoVsl+QSdxKK48="
     else
-      "";
+      "sha256-NI4BOsbyLXADN35xz3QM6TVE4ozl92PSAItCT/2Ki3A=";
 
   subPackages = [ "cmd/kots/" ];
 

--- a/pkgs/kots/default.nix
+++ b/pkgs/kots/default.nix
@@ -5,19 +5,19 @@ let
 in
 buildGoModule rec {
   pname = "kots";
-  version = "1.124.16";
+  version = "1.128.0";
 
   src = fetchFromGitHub {
     owner = "replicatedhq";
     repo = "kots";
     rev = "v${version}";
-    sha256 = "sha256-U9nXbho+gIqgdMF/za09J83zhLIZWnJwoA0ZWNq765g=";
+    sha256 = "sha256-NnXYqF4yqBUuckK/pgnADy3GlQZyughoKieXF1Y8X94=";
   };
 
   vendorHash = if isDarwin then 
-      "sha256-m4pvaR2206p1RIpG/dt7/6Oz+Q9+dydGIBjAIYVC89g="
+      "sha256-gwbXiYt70cKa6daMKDW3d++R8Ix8PDoVsl+QSdxKK48="
     else
-      "sha256-nD9/ypW7xTvfo9B/vt8/WlHFtic4EScga7VuURbkHIE=";
+      "";
 
   subPackages = [ "cmd/kots/" ];
 

--- a/pkgs/replicated/default.nix
+++ b/pkgs/replicated/default.nix
@@ -17,7 +17,7 @@ buildGoModule rec {
   vendorHash = if isDarwin then
       "sha256-MQN6em11fDxbTLi4UsrmJKMIRrqg2cmWAqFtYMkWiwg="
     else
-      "";
+      "sha256-jmLT3ViYI+NzBaxSZzJJC++oPxsSOKXm3rnwFySGIRg=";
 
   subPackages = [ "cli/cmd/" ];
   ldflags = [

--- a/pkgs/replicated/default.nix
+++ b/pkgs/replicated/default.nix
@@ -5,19 +5,19 @@ let
 in
 buildGoModule rec {
   pname = "replicated";
-  version = "0.106.0";
+  version = "0.114.0";
 
   src = fetchFromGitHub {
     owner = "replicatedhq";
     repo = "replicated";
     rev = "v${version}";
-    sha256 = "sha256-CbNHqHabqMqN8bHR9kvi1bZpCWsrohk0bkzppDyQ9+Y=";
+    sha256 = "sha256-9fQNKBqJfqvTOsLeebiWC1JSsqiGyjmwZYXVE/ynY0s=";
   };
 
   vendorHash = if isDarwin then
-      "sha256-OYm8Jd0kLRU3K4fb6kPoPiCJClpger9JSZVoY5WEriQ="
+      "sha256-MQN6em11fDxbTLi4UsrmJKMIRrqg2cmWAqFtYMkWiwg="
     else
-      "sha256-7riSSbWN0jplKOMiAwic4NWp1qKZ0sUc0ZzScUrPxFw=";
+      "";
 
   subPackages = [ "cli/cmd/" ];
   ldflags = [

--- a/pkgs/sbctl/default.nix
+++ b/pkgs/sbctl/default.nix
@@ -7,15 +7,15 @@ let
   isLinux = stdenv.isLinux;
 in stdenv.mkDerivation rec {
   pname = "troubeleshoot-sbctl";
-  version = "0.17.1";
+  version = "0.17.3";
 
   src = fetchzip {
     url = "https://github.com/replicatedhq/sbctl/releases/download/v${version}/sbctl_${os}_${arch}.tar.gz";
     stripRoot = false;
     sha256 = if isDarwin then
-        "sha256-4kRgTEq0imBnOjDH5nZyN972FASFVKVXMi0DNvnddvM="
+        "sha256-Ueok5X7GVnHgj/YLcjdlKnyqP6Pg3lGAsFNDerz2Mu8="
       else
-        "sha256-+72HlYquAK5dOeZHnkpZZflOARg7wC+gF6uYzGQA93U=";
+        "";
   };
 
   # Install the binary

--- a/pkgs/sbctl/default.nix
+++ b/pkgs/sbctl/default.nix
@@ -15,7 +15,7 @@ in stdenv.mkDerivation rec {
     sha256 = if isDarwin then
         "sha256-Ueok5X7GVnHgj/YLcjdlKnyqP6Pg3lGAsFNDerz2Mu8="
       else
-        "";
+        "sha256-7qfaMfqMWmvpay1fZXwX8eGNdrD4mSa9UZC8OqZNZaQ=";
   };
 
   # Install the binary

--- a/pkgs/vimr/default.nix
+++ b/pkgs/vimr/default.nix
@@ -2,12 +2,12 @@
 
 stdenv.mkDerivation rec {
   pname = "vimr";
-  version = "v0.54.0";
-  build = "20250531.222551";
+  version = "v0.57.0";
+  build = "20250901.212156";
 
   src = fetchurl {
     url = "https://github.com/qvacua/vimr/releases/download/${version}-${build}/VimR-${version}.tar.bz2";
-    sha256 = "sha256-5ybAIn4EpZs7kV0bJch2mEpNZ7Ws/C+1tSkujLLmZAU=";
+    sha256 = "sha256-ZMMcqTMC09hFBpfEYQD8uaZ7BvQ1ZpxxPlZqqEQa9do=";
   };
 
   dontFixup = true;


### PR DESCRIPTION
TL;DR
-----

Integrates Crush AI assistant alongside existing tools while upgrading several dependencies to their latest versions and improving developer tooling across modules.

Details
--------

Adds support for the Crush AI assistant from Charmbracelet's NUR repository, expanding our diverse toolkit of AI assistants for different development and content creation needs. The integration reflects our strategy of maintaining multiple specialized AI tools rather than relying on a single solution.

Upgrades the Claude AI model for community posts from sonnet to opus, enhancing our content generation capabilities. New SlackerNews documentation templates streamline our documentation workflows, while several unused tools have been removed to keep the codebase lean.

Critical tools and components received significant updates: kots advanced from 1.124.16 to 1.128.0, replicated jumped from 0.106.0 to 0.114.0, and sbctl moved from 0.17.1 to 0.17.3. These upgrades bring the latest features and security patches. VimR's update to 0.57.0 from 0.54.0 improves the macOS editor experience.

The Claude Code integration for Neovim now runs with proper configuration through `require('claude-code').setup({})`. We've switched the Goose provider from Anthropic to Claude Code, streamlining our AI assistance workflow and removing several unused MCP server extensions in the process.

Finally, we've added `.crush` to `.gitignore`, preventing local Crush AI configurations from accidentally entering the repository.
