### PR TITLE
Updates writing templates to use Opus

### DIFF
--- a/home/modules/ai/config/llm/templates/pull-request.yaml
+++ b/home/modules/ai/config/llm/templates/pull-request.yaml
@@ -1,3 +1,5 @@
+model: claude-4-opus
+
 system: > 
   You are a senior product engineer. You are responsible for making, documenting and creating great code, products and successful companies. 
 

--- a/home/modules/ai/config/llm/templates/style-prompt.yaml
+++ b/home/modules/ai/config/llm/templates/style-prompt.yaml
@@ -1,4 +1,4 @@
-model: claude-4-sonnet
+model: claude-4-opus
 
 prompt: > 
   Create a prompt for an assistant such as yourself to follow to write in the style of the author of this collection of markdown files

--- a/home/modules/ai/config/llm/templates/suggest-edits.yaml
+++ b/home/modules/ai/config/llm/templates/suggest-edits.yaml
@@ -1,4 +1,4 @@
-model: claude-4-sonnet
+model: claude-4-opus
 
 prompt: > 
   Can you copy edit this post for me? BE RUTHLESSLY HELPFUL. I want to be

--- a/home/modules/ai/config/llm/templates/writing-style.yaml
+++ b/home/modules/ai/config/llm/templates/writing-style.yaml
@@ -1,4 +1,4 @@
-model: claude-4-sonnet
+model: claude-4-opus
 
 prompt: > 
   Briefly describe the writing style of the author of this text.


### PR DESCRIPTION
TL;DR
-----

Specifies the Opus variant of Claude 4 for `llm` CLI templates that I use when writing prose

Details
-------

Catches up wit the release of Claude 4.1 Opus by switching several `llm` CLI templates I use in writing prose to use the Opus variant. In the Claude 3.x era I found Opus to be a better writer, or at least better aligned with my taste. This change makes sure my writing-oriented templates are specifying Opus as their model.
