### PR TITLE
Refreshes a few things

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -28,11 +28,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1749744770,
-        "narHash": "sha256-MEM9XXHgBF/Cyv1RES1t6gqAX7/tvayBC1r/KPyK1ls=",
+        "lastModified": 1757432263,
+        "narHash": "sha256-qHn+/0+IOz5cG68BZUwL9BV3EO/e9eNKCjH3+N7wMdI=",
         "owner": "lnl7",
         "repo": "nix-darwin",
-        "rev": "536f951efb1ccda9b968e3c9dee39fbeb6d3fdeb",
+        "rev": "1fef4404de4d1596aa5ab2bd68078370e1b9dcdb",
         "type": "github"
       },
       "original": {
@@ -70,11 +70,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1756679287,
-        "narHash": "sha256-Xd1vOeY9ccDf5VtVK12yM0FS6qqvfUop8UQlxEB+gTQ=",
+        "lastModified": 1758463745,
+        "narHash": "sha256-uhzsV0Q0I9j2y/rfweWeGif5AWe0MGrgZ/3TjpDYdGA=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "07fc025fe10487dd80f2ec694f1cd790e752d0e8",
+        "rev": "3b955f5f0a942f9f60cdc9cacb7844335d0f21c3",
         "type": "github"
       },
       "original": {
@@ -86,11 +86,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1757244434,
-        "narHash": "sha256-AeqTqY0Y95K1Fgs6wuT1LafBNcmKxcOkWnm4alD9pqM=",
+        "lastModified": 1759099612,
+        "narHash": "sha256-izLrnUcdFW+Gvff+d6l+bFouaMAVPoxfgF/wCrb3B3s=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "092c565d333be1e17b4779ac22104338941d913f",
+        "rev": "b13819b6a6db52d8ce2609a121ab6cfa1e8058f7",
         "type": "github"
       },
       "original": {
@@ -102,11 +102,11 @@
     },
     "nixpkgs-unstable": {
       "locked": {
-        "lastModified": 1757034884,
-        "narHash": "sha256-PgLSZDBEWUHpfTRfFyklmiiLBE1i1aGCtz4eRA3POao=",
+        "lastModified": 1759070547,
+        "narHash": "sha256-JVZl8NaVRYb0+381nl7LvPE+A774/dRpif01FKLrYFQ=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "ca77296380960cd497a765102eeb1356eb80fed0",
+        "rev": "647e5c14cbd5067f44ac86b74f014962df460840",
         "type": "github"
       },
       "original": {
@@ -118,11 +118,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1744868846,
-        "narHash": "sha256-5RJTdUHDmj12Qsv7XOhuospjAjATNiTMElplWnJE9Hs=",
+        "lastModified": 1758976413,
+        "narHash": "sha256-hEIDTaIqvW1NMfaNgz6pjhZPZKTmACJmXxGr/H6isIg=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "ebe4301cbd8f81c4f8d3244b3632338bbeb6d49c",
+        "rev": "e3a3b32cc234f1683258d36c6232f150d57df015",
         "type": "github"
       },
       "original": {
@@ -140,11 +140,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1757362860,
-        "narHash": "sha256-l1O6ElJg0XJoejyy3ZHE+Wk2Q3rm897NIHURzgY5wjw=",
+        "lastModified": 1759260470,
+        "narHash": "sha256-7KFWm6l+qJl+b1XAx9D8isjCb2kluJEGzquZxmJPEL4=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "759e9f7b4353971a1c087eeb44064252efb3ac3b",
+        "rev": "2b8508603232941676978619d6d4b34fc9e0b486",
         "type": "github"
       },
       "original": {
@@ -169,11 +169,11 @@
         "nixpkgs": "nixpkgs_2"
       },
       "locked": {
-        "lastModified": 1754988908,
-        "narHash": "sha256-t+voe2961vCgrzPFtZxha0/kmFSHFobzF00sT8p9h0U=",
+        "lastModified": 1759188042,
+        "narHash": "sha256-f9QC2KKiNReZDG2yyKAtDZh0rSK2Xp1wkPzKbHeQVRU=",
         "owner": "Mic92",
         "repo": "sops-nix",
-        "rev": "3223c7a92724b5d804e9988c6b447a0d09017d48",
+        "rev": "9fcfabe085281dd793589bdc770a2e577a3caa5d",
         "type": "github"
       },
       "original": {

--- a/home/modules/ai/default.nix
+++ b/home/modules/ai/default.nix
@@ -10,7 +10,7 @@ in {
       aider-chat-full
       amp-cli
       nur.repos.charmbracelet.crush
-      unstable.claude-code
+      claude-code
       unstable.fabric-ai
       gemini-cli
       goose-cli

--- a/home/modules/kubernetes/default.nix
+++ b/home/modules/kubernetes/default.nix
@@ -20,11 +20,8 @@ in {
       kubeseal
       kustomize
       kyverno-chainsaw
-      unstable.open-policy-agent
-      replicated
+      # open-policy-agent
       stern
-      troubleshoot-sbctl
-      tunnelmanager
       vendir
       ytt
     ] ++ lib.optionals isLinux [

--- a/home/modules/security/default.nix
+++ b/home/modules/security/default.nix
@@ -16,6 +16,7 @@ in {
         cosign
         sops
         syft
+        tunnelmanager
         # yubico-pam
         yubico-piv-tool
         yubikey-manager

--- a/overlays/default.nix
+++ b/overlays/default.nix
@@ -7,6 +7,22 @@
   # You can change versions, add patches, set compilation flags, anything really.
   # https://nixos.wiki/wiki/Overlays
   modifications = final: prev: {
+    go1_25 = prev.go.overrideAttrs (oldAttrs: let
+      newVersion = "1.25.1";
+      in {
+        version = newVersion;
+        src = prev.fetchzip {
+          url = "https://go.dev/dl/go${newVersion}.src.tar.gz";
+          hash = "sha256-jz/CjhXI4jMFHhg7Up/X1FbUyMRTFM1fim3Gj77cU9Q=";
+        };
+        patches = [];
+      }
+    );
+
+    buildGo1_25Module = prev.buildGoModule.override {
+      go = final.go;
+    };
+
     vimPlugins = prev.vimPlugins // {
       nvim-aider = prev.callPackage ./nvim-aider { };
       # xcodebuild-nvim = prev.callPackage ./xcodebuild-nvim { }; 
@@ -20,18 +36,31 @@
     llm = prev.callPackage ./llm { };
     
     tailscale = (prev.tailscale.overrideAttrs (oldAttrs: let 
-      newVersion = "1.84.2";
+      newVersion = "1.88.3";
     in {
       version = newVersion;
       src = prev.fetchFromGitHub {
         owner = "tailscale";
         repo = "tailscale";
         rev = "v${newVersion}";
-        sha256 = "sha256-dSYophk7oogLmlRBr05Quhx+iMUuJU2VXhAZVtJLTts=";
+        sha256 = "sha256-gw4oexTyJGeBkCd07RQQdfY14xArgVIMDHKrWu9K+9Q=";
       };
-      vendorHash = "sha256-QBYCMOWQOBCt+69NtJtluhTZIOiBWcQ78M9Gbki6bN0=";
-      doCheck = false; # Disable tests due to undefined symbols in v1.84.2
+      vendorHash = "sha256-8aE6dWMkTLdWRD9WnLVSzpOQQh61voEnjZAJHtbGCSs=";
+      doCheck = false;
+    })).override{ buildGoModule = final.buildGo1_25Module; };
+
+    kots = prev.kots.override{ buildGoModule = final.buildGo1_25Module; };
+
+    claude-code = (prev.claude-code.overrideAttrs (oldAttrs: let 
+      newVersion = "2.0.1";
+    in {
+      version = newVersion;
+      src = prev.fetchzip {
+        url = "https://registry.npmjs.org/@anthropic-ai/claude-code/-/claude-code-${newVersion}.tgz";
+        hash = "sha256-LUbDPFa0lY74MBU4hvmYVntt6hVZy6UUZFN0iB4Eno8=";
+      };
     }));
+
   };
 
   # When applied, the unstable nixpkgs set (declared in the flake inputs) will

--- a/pkgs/kots/default.nix
+++ b/pkgs/kots/default.nix
@@ -17,7 +17,7 @@ buildGoModule rec {
   vendorHash = if isDarwin then 
       "sha256-1A0I5Iw+5yTiSCMElSO3FIveAo4nkSTqUf0K0bvcpIs="
     else
-      "";
+      "sha256-ITOJoxEmHIpTpych42Ad03CRB5TKPlNELMK2hXuamkk=";
 
   subPackages = [ "cmd/kots/" ];
 

--- a/pkgs/kots/default.nix
+++ b/pkgs/kots/default.nix
@@ -5,19 +5,19 @@ let
 in
 buildGoModule rec {
   pname = "kots";
-  version = "1.128.0";
+  version = "1.128.2";
 
   src = fetchFromGitHub {
     owner = "replicatedhq";
     repo = "kots";
     rev = "v${version}";
-    sha256 = "sha256-NnXYqF4yqBUuckK/pgnADy3GlQZyughoKieXF1Y8X94=";
+    sha256 = "sha256-ArBDD+ntl+AX1l1dXA524MS3MzUYbfG8c29nBzMeRB0=";
   };
 
   vendorHash = if isDarwin then 
-      "sha256-gwbXiYt70cKa6daMKDW3d++R8Ix8PDoVsl+QSdxKK48="
+      "sha256-1A0I5Iw+5yTiSCMElSO3FIveAo4nkSTqUf0K0bvcpIs="
     else
-      "sha256-NI4BOsbyLXADN35xz3QM6TVE4ozl92PSAItCT/2Ki3A=";
+      "";
 
   subPackages = [ "cmd/kots/" ];
 


### PR DESCRIPTION
TL;DR
-----

Lightly updates a few packages

Details
-------

Updates our flake, Tailscale, Claude Code, and KOTS. This required
adding a variant function to build Go packages with the 1.25 line and
surfaced a couple of other things I needed to deal with: the OPA CLI
was struggling to build and I had a few packages that were Replicated
specific tied to the Kubernetee module in my Home Manager
configuration. All are addressed.
