### PR TITLE
Compiles Tailscale with the right version of Go

### DIFF
--- a/overlays/default.nix
+++ b/overlays/default.nix
@@ -20,7 +20,7 @@
     );
 
     buildGo1_25Module = prev.buildGoModule.override {
-      go = final.go;
+      go = final.go1_25;
     };
 
     vimPlugins = prev.vimPlugins // {


### PR DESCRIPTION
TL;DR
-----

Makes a minor change to actually use Go 1.25 to compie the version of Tailscale requiring it

Details
-------

Corrects an error where I wasn't using the overlaid version of Go to compile Tailscale after I explicitly set it up for that puprose.
