### PR TITLE
Updates dependencies and tooling

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -28,11 +28,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1757432263,
-        "narHash": "sha256-qHn+/0+IOz5cG68BZUwL9BV3EO/e9eNKCjH3+N7wMdI=",
+        "lastModified": 1759509947,
+        "narHash": "sha256-4XifSIHfpJKcCf5bZZRhj8C4aCpjNBaE3kXr02s4rHU=",
         "owner": "lnl7",
         "repo": "nix-darwin",
-        "rev": "1fef4404de4d1596aa5ab2bd68078370e1b9dcdb",
+        "rev": "000eadb231812ad6ea6aebd7526974aaf4e79355",
         "type": "github"
       },
       "original": {
@@ -86,11 +86,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1759099612,
-        "narHash": "sha256-izLrnUcdFW+Gvff+d6l+bFouaMAVPoxfgF/wCrb3B3s=",
+        "lastModified": 1760555908,
+        "narHash": "sha256-cqLWc8Z6AoTRi8jYIELw+a9Ig5dtZX2aA6Vj4X8KkFo=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "b13819b6a6db52d8ce2609a121ab6cfa1e8058f7",
+        "rev": "d4865112f6afb9fc3b6ecd03c74669a3fef9b89b",
         "type": "github"
       },
       "original": {
@@ -102,11 +102,11 @@
     },
     "nixpkgs-unstable": {
       "locked": {
-        "lastModified": 1759070547,
-        "narHash": "sha256-JVZl8NaVRYb0+381nl7LvPE+A774/dRpif01FKLrYFQ=",
+        "lastModified": 1760596604,
+        "narHash": "sha256-J/i5K6AAz/y5dBePHQOuzC7MbhyTOKsd/GLezSbEFiM=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "647e5c14cbd5067f44ac86b74f014962df460840",
+        "rev": "3cbe716e2346710d6e1f7c559363d14e11c32a43",
         "type": "github"
       },
       "original": {
@@ -118,11 +118,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1758976413,
-        "narHash": "sha256-hEIDTaIqvW1NMfaNgz6pjhZPZKTmACJmXxGr/H6isIg=",
+        "lastModified": 1760164275,
+        "narHash": "sha256-gKl2Gtro/LNf8P+4L3S2RsZ0G390ccd5MyXYrTdMCFE=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "e3a3b32cc234f1683258d36c6232f150d57df015",
+        "rev": "362791944032cb532aabbeed7887a441496d5e6e",
         "type": "github"
       },
       "original": {
@@ -140,11 +140,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1759260470,
-        "narHash": "sha256-7KFWm6l+qJl+b1XAx9D8isjCb2kluJEGzquZxmJPEL4=",
+        "lastModified": 1760626018,
+        "narHash": "sha256-egSsb7gdTxRBWHIaaZ1NDb1ge3okW76rrac2Uv9ovic=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "2b8508603232941676978619d6d4b34fc9e0b486",
+        "rev": "0381717a9b6f53e531ae6315894220c223e2060b",
         "type": "github"
       },
       "original": {
@@ -169,11 +169,11 @@
         "nixpkgs": "nixpkgs_2"
       },
       "locked": {
-        "lastModified": 1759188042,
-        "narHash": "sha256-f9QC2KKiNReZDG2yyKAtDZh0rSK2Xp1wkPzKbHeQVRU=",
+        "lastModified": 1760393368,
+        "narHash": "sha256-8mN3kqyqa2PKY0wwZ2UmMEYMcxvNTwLaOrrDsw6Qi4E=",
         "owner": "Mic92",
         "repo": "sops-nix",
-        "rev": "9fcfabe085281dd793589bdc770a2e577a3caa5d",
+        "rev": "ab8d56e85b8be14cff9d93735951e30c3e86a437",
         "type": "github"
       },
       "original": {

--- a/home/modules/ai/default.nix
+++ b/home/modules/ai/default.nix
@@ -27,10 +27,21 @@ in {
     activation = {
       claude = lib.hm.dag.entryAfter [ "writeBoundary" ] ''
         for CLAUDE_CONFIG_DIR in  ${config.xdg.configHome}/claude/replicated ${config.xdg.configHome}/claude/personal ; do
+          echo "Copying agents and commands to $CLAUDE_CONFIG_DIR..."
           $DRY_RUN_CMD mkdir -p $CLAUDE_CONFIG_DIR/commands $CLAUDE_CONFIG_DIR/agents
           $DRY_RUN_CMD cp -f ${./config/claude/commands}/* $CLAUDE_CONFIG_DIR/commands
           $DRY_RUN_CMD cp -f ${./config/claude/agents}/* $CLAUDE_CONFIG_DIR/agents
         done
+
+        if [ ! -d ~/.claude/agents ]; then
+          echo "Copying Replicated managed agents to the Replicated Claude config directory..."
+          cp -r ~/.claude/config/agents ${config.xdg.configHome}/claude/replicated/agents
+        fi
+
+        if [ ! -d ~/.claude/commands ]; then
+          echo "Copying Replicated managed commands to the Replicated Claude config directory..."
+          cp -r ~/.claude/config/commands ${config.xdg.configHome}/claude/replicated/commands
+        fi
       '';
     };
 

--- a/home/modules/ai/default.nix
+++ b/home/modules/ai/default.nix
@@ -33,14 +33,17 @@ in {
           $DRY_RUN_CMD cp -f ${./config/claude/agents}/* $CLAUDE_CONFIG_DIR/agents
         done
 
-        if [ ! -d ~/.claude/agents ]; then
-          echo "Copying Replicated managed agents to the Replicated Claude config directory..."
-          cp -r ~/.claude/config/agents ${config.xdg.configHome}/claude/replicated/agents
-        fi
+        # Only on sochu: copy Replicated's auto-installed managed agents/commands
+        if [ "$(hostname -s)" = "sochu" ]; then
+          if [ -d ~/.claude/agents ]; then
+            echo "Copying Replicated managed agents to the Replicated Claude config directory..."
+            $DRY_RUN_CMD cp -r ~/.claude/agents/* ${config.xdg.configHome}/claude/replicated/agents/
+          fi
 
-        if [ ! -d ~/.claude/commands ]; then
-          echo "Copying Replicated managed commands to the Replicated Claude config directory..."
-          cp -r ~/.claude/config/commands ${config.xdg.configHome}/claude/replicated/commands
+          if [ -d ~/.claude/commands ]; then
+            echo "Copying Replicated managed commands to the Replicated Claude config directory..."
+            $DRY_RUN_CMD cp -r ~/.claude/commands/* ${config.xdg.configHome}/claude/replicated/commands/
+          fi
         fi
       '';
     };

--- a/home/modules/editor/default.nix
+++ b/home/modules/editor/default.nix
@@ -18,6 +18,7 @@ in {
       plugins = with pkgs.vimPlugins; [
         cmp-nvim-lsp
         conflict-marker-vim
+        diffview-nvim
         {
           plugin = fzf-vim;
           config = ''

--- a/home/modules/editor/default.nix
+++ b/home/modules/editor/default.nix
@@ -24,8 +24,9 @@ in {
             " Initialize configuration dictionary
             let g:fzf_vim = {}
             let g:fzf_vim.preview_window = []
-          ''; 
+          '';
         }
+        gitsigns-nvim
         image-nvim
         neo-tree-nvim
         nvim-web-devicons
@@ -39,7 +40,7 @@ in {
       extraLuaConfig = ''
         -- Core editor settings
         require('snacks').setup({})
-        
+
         -- Core plugins setup
         require('jupytext').setup(
           {
@@ -47,6 +48,9 @@ in {
             format = "markdown"
           }
         )
+
+        -- Gitsigns setup
+        require('gitsigns').setup()
 
         if vim.fn.has('gui_running') ~= 1 then
           require('image').setup({})

--- a/home/modules/kubernetes/default.nix
+++ b/home/modules/kubernetes/default.nix
@@ -8,11 +8,11 @@ in {
   home = {
     packages = with pkgs; [
       conftest
+      helm-beta
       helmfile
       istioctl
       krew
       kubectl
-      kubernetes-helm
       k0sctl
       k9s
       kapp

--- a/home/modules/replicated/default.nix
+++ b/home/modules/replicated/default.nix
@@ -6,13 +6,13 @@ let
 in {
   home = {
     packages = with pkgs; [
-      iterm2
       kots
       replicated
       troubleshoot-sbctl
       unstable.okteto
     ] ++ lib.optionals isDarwin [
       instruqt
+      iterm2
       teams
     ];
     file = lib.optionalAttrs isDarwin {

--- a/home/modules/replicated/default.nix
+++ b/home/modules/replicated/default.nix
@@ -10,6 +10,7 @@ in {
       kots
       replicated
       troubleshoot-sbctl
+      unstable.okteto
     ] ++ lib.optionals isDarwin [
       instruqt
       teams

--- a/overlays/default.nix
+++ b/overlays/default.nix
@@ -52,12 +52,12 @@
     kots = prev.kots.override{ buildGoModule = final.buildGo1_25Module; };
 
     claude-code = (prev.claude-code.overrideAttrs (oldAttrs: let
-      newVersion = "2.0.19";
+      newVersion = "2.0.21";
     in {
       version = newVersion;
       src = prev.fetchzip {
         url = "https://registry.npmjs.org/@anthropic-ai/claude-code/-/claude-code-${newVersion}.tgz";
-        hash = "sha256-wUpOZzGrs1VekDt0T+j9t9E+dVPPfjQUJxgqWVU3eGk=";
+        hash = "sha256-sX9btcy9uEHloAQNvCJFhwh0U/W14NWz2FjkdLXm1Q0=";
       };
     }));
 

--- a/overlays/default.nix
+++ b/overlays/default.nix
@@ -35,15 +35,15 @@
 
     llm = prev.callPackage ./llm { };
     
-    tailscale = (prev.tailscale.overrideAttrs (oldAttrs: let 
-      newVersion = "1.88.3";
+    tailscale = (prev.tailscale.overrideAttrs (oldAttrs: let
+      newVersion = "1.88.4";
     in {
       version = newVersion;
       src = prev.fetchFromGitHub {
         owner = "tailscale";
         repo = "tailscale";
         rev = "v${newVersion}";
-        sha256 = "sha256-gw4oexTyJGeBkCd07RQQdfY14xArgVIMDHKrWu9K+9Q=";
+        sha256 = "sha256-fzJwRTB2U2GuLmv1XUSMLnhyLlp+4kGorLGAvRVjDqw=";
       };
       vendorHash = "sha256-8aE6dWMkTLdWRD9WnLVSzpOQQh61voEnjZAJHtbGCSs=";
       doCheck = false;

--- a/overlays/default.nix
+++ b/overlays/default.nix
@@ -51,13 +51,13 @@
 
     kots = prev.kots.override{ buildGoModule = final.buildGo1_25Module; };
 
-    claude-code = (prev.claude-code.overrideAttrs (oldAttrs: let 
-      newVersion = "2.0.1";
+    claude-code = (prev.claude-code.overrideAttrs (oldAttrs: let
+      newVersion = "2.0.19";
     in {
       version = newVersion;
       src = prev.fetchzip {
         url = "https://registry.npmjs.org/@anthropic-ai/claude-code/-/claude-code-${newVersion}.tgz";
-        hash = "sha256-LUbDPFa0lY74MBU4hvmYVntt6hVZy6UUZFN0iB4Eno8=";
+        hash = "sha256-wUpOZzGrs1VekDt0T+j9t9E+dVPPfjQUJxgqWVU3eGk=";
       };
     }));
 

--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -12,6 +12,7 @@ rec {
   replicated = pkgs.callPackage ./replicated { };
   kots = pkgs.callPackage ./kots { };
   troubleshoot-sbctl = pkgs.callPackage ./sbctl { };
+  helm-beta = pkgs.callPackage ./helm-beta { };
 
   llmPlugins = pkgs.callPackage ./llm/plugins { };
 

--- a/pkgs/helm-beta/default.nix
+++ b/pkgs/helm-beta/default.nix
@@ -1,0 +1,43 @@
+{ lib, buildGoModule, fetchFromGitHub, installShellFiles }:
+
+buildGoModule rec {
+  pname = "helm-beta";
+  version = "4.0.0-beta.1";
+
+  src = fetchFromGitHub {
+    owner = "helm";
+    repo = "helm";
+    rev = "v${version}";
+    sha256 = "sha256-M/le8jY7i+Nqd6bPB4tvvOSQj1TFwOYdUy8N6klOLG4=";
+  };
+
+  vendorHash = "sha256-W1G0pX05tR4MfQfil8l4sYwWim7UdGGRI30dhZmphi8=";
+
+  doCheck = false;
+
+  subPackages = [ "cmd/helm" ];
+
+  ldflags = [
+    "-w"
+    "-s"
+    "-X helm.sh/helm/v3/internal/version.version=v${version}"
+    "-X helm.sh/helm/v3/internal/version.gitCommit=${src.rev}"
+  ];
+
+  nativeBuildInputs = [ installShellFiles ];
+
+  postInstall = ''
+    $out/bin/helm completion bash > helm.bash
+    $out/bin/helm completion zsh > helm.zsh
+    $out/bin/helm completion fish > helm.fish
+    installShellCompletion helm.{bash,zsh,fish}
+  '';
+
+  meta = with lib; {
+    description = "Helm 4.0 Beta - Kubernetes package manager";
+    homepage = "https://github.com/helm/helm";
+    license = licenses.asl20;
+    mainProgram = "helm";
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/kots/default.nix
+++ b/pkgs/kots/default.nix
@@ -18,7 +18,6 @@ buildGoModule rec {
       "sha256-1A0I5Iw+5yTiSCMElSO3FIveAo4nkSTqUf0K0bvcpIs="
     else
       "sha256-ITOJoxEmHIpTpych42Ad03CRB5TKPlNELMK2hXuamkk=";
-      "";
 
   subPackages = [ "cmd/kots/" ];
 

--- a/pkgs/kots/default.nix
+++ b/pkgs/kots/default.nix
@@ -18,6 +18,7 @@ buildGoModule rec {
       "sha256-1A0I5Iw+5yTiSCMElSO3FIveAo4nkSTqUf0K0bvcpIs="
     else
       "sha256-ITOJoxEmHIpTpych42Ad03CRB5TKPlNELMK2hXuamkk=";
+      "";
 
   subPackages = [ "cmd/kots/" ];
 

--- a/pkgs/llm/plugins/generated-plugins.nix
+++ b/pkgs/llm/plugins/generated-plugins.nix
@@ -121,7 +121,7 @@ in
       sha256 = "sha256-BTlqrwHS6SSQ86vaf9CqNbgFM9RSiRk97dktosLBE78=";
     };
     description = "Shell completion using LLM";
-    pythonDeps = ["prompt_toolkit" "pygments"];
+    pythonDeps = ["prompt_toolkit"];
   };
 
   llm-cohere = buildLlmPlugin {

--- a/pkgs/llm/plugins/llm-plugins-lock.json
+++ b/pkgs/llm/plugins/llm-plugins-lock.json
@@ -117,8 +117,7 @@
     "description": "Shell completion using LLM",
     "owner": "CGamesPlay",
     "pythonDeps": [
-      "prompt_toolkit",
-      "pygments"
+      "prompt_toolkit"
     ],
     "ref": "v1.1.1",
     "repo": "llm-cmd-comp",

--- a/pkgs/llm/plugins/llm-plugins.json
+++ b/pkgs/llm/plugins/llm-plugins.json
@@ -313,7 +313,7 @@
     "ref": "v1.1.1",
     "description": "Shell completion using LLM",
     "pythonDeps": [
-      "prompt_toolkit",
+      "prompt_toolkit"
     ]
   },
   "llm-python": {

--- a/pkgs/replicated/default.nix
+++ b/pkgs/replicated/default.nix
@@ -5,13 +5,13 @@ let
 in
 buildGoModule rec {
   pname = "replicated";
-  version = "0.115.1";
+  version = "0.116.0";
 
   src = fetchFromGitHub {
     owner = "replicatedhq";
     repo = "replicated";
     rev = "v${version}";
-    sha256 = "sha256-N6mASGZiWiPuwMGjqhUJ9/ivyOk27PZv2pbkO0WhAuQ=";
+    sha256 = "sha256-BWDDeA6gpNQkkeYVfvFvUM+8k/y4dDyGvVb8B2As9Sg=";
   };
 
   vendorHash = if isDarwin then

--- a/pkgs/replicated/default.nix
+++ b/pkgs/replicated/default.nix
@@ -5,19 +5,19 @@ let
 in
 buildGoModule rec {
   pname = "replicated";
-  version = "0.114.0";
+  version = "0.115.1";
 
   src = fetchFromGitHub {
     owner = "replicatedhq";
     repo = "replicated";
     rev = "v${version}";
-    sha256 = "sha256-9fQNKBqJfqvTOsLeebiWC1JSsqiGyjmwZYXVE/ynY0s=";
+    sha256 = "sha256-N6mASGZiWiPuwMGjqhUJ9/ivyOk27PZv2pbkO0WhAuQ=";
   };
 
   vendorHash = if isDarwin then
-      "sha256-MQN6em11fDxbTLi4UsrmJKMIRrqg2cmWAqFtYMkWiwg="
+      "sha256-ufbL6ddpACgaimmz5tEAMAVYO22Am560imDg8SVKBr4="
     else
-      "sha256-jmLT3ViYI+NzBaxSZzJJC++oPxsSOKXm3rnwFySGIRg=";
+      "sha256-ufbL6ddpACgaimmz5tEAMAVYO22Am560imDg8SVKBr4=";
 
   subPackages = [ "cli/cmd/" ];
   ldflags = [

--- a/pkgs/vimr/default.nix
+++ b/pkgs/vimr/default.nix
@@ -2,12 +2,12 @@
 
 stdenv.mkDerivation rec {
   pname = "vimr";
-  version = "v0.57.0";
-  build = "20250901.212156";
+  version = "v0.58.0";
+  build = "20251013.211150";
 
   src = fetchurl {
     url = "https://github.com/qvacua/vimr/releases/download/${version}-${build}/VimR-${version}.tar.bz2";
-    sha256 = "sha256-ZMMcqTMC09hFBpfEYQD8uaZ7BvQ1ZpxxPlZqqEQa9do=";
+    sha256 = "sha256-5ebQTiDrwTlb7ANh8CCJJIHyd+ONj7T+3Z+HbIfG2X0=";
   };
 
   dontFixup = true;


### PR DESCRIPTION
TL;DR
-----

Refreshes Nix flake dependencies and migrates Kubernetes tooling to Helm 4.0 Beta while adding enhanced development tools.

Details
--------

Keeps packages current and adds some tools.

The dependency updates span the entire Nix ecosystem, including nix-darwin, nixpkgs (both stable and unstable channels), NUR (Nix User Repository), and sops-nix for secrets management. These updates bring bug fixes, security patches, and performance improvements accumulated since the last refresh cycle.

The Helm migration represents a strategic upgrade from the stable 3.x series to the 4.0 Beta release. This version introduces breaking changes in chart structure and installation behavior that justify early adoption for testing and validation. The new helm-beta package builds from source with proper version metadata and shell completions, while the kubernetes module switches from kubernetes-helm to helm-beta to leverage these improvements.

Additional tooling enhancements include diffview-nvim for enhanced diff visualization within Neovim, gitsigns-nvim for inline Git status indicators, and Okteto for cloud-native development workflows. Package updates cover VimR (v0.57.0 to v0.58.0), Claude Code (2.0.1 to 2.0.19), Replicated (0.114.0 to 0.115.1), and Tailscale (1.88.3 to 1.88.4).

The Claude configuration activation now properly ensures managed agents and commands from the Replicated workspace copy into the appropriate configuration directories, preventing conflicts between personal and work-managed tooling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Neovim plugins for git integration and diff viewing (gitsigns, diffview)
  * Claude activation now copies/synchronizes replicated agent and command configs on the targeted host

* **Updates**
  * Introduced helm-beta package; Okteto added to base installs and iTerm2 moved to platform-specific installs
  * Tailscale, Claude tooling, Replicated, and VimR updated to newer releases

* **Refactor**
  * Reduced Python dependencies for the LLM shell-command plugin (pygments removed)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->