### PR TITLE
Fixes GitHub Actions workflows for package automation

### DIFF
--- a/.github/workflows/check-package-status.yml
+++ b/.github/workflows/check-package-status.yml
@@ -23,7 +23,7 @@ jobs:
 
           # Get list of available packages dynamically
           # Capture both stdout and stderr, but preserve them separately for diagnostics
-          script_output=$(python3 .github/scripts/update-package.py 2>&1)
+          script_output=$(nix-shell -p python3 python3Packages.requests --run "python3 .github/scripts/update-package.py" 2>&1)
           script_exit_code=$?
 
           # Note the exit code but don't fail yet - the script exits 1 on usage/help

--- a/.github/workflows/update-kots.yml
+++ b/.github/workflows/update-kots.yml
@@ -128,15 +128,7 @@ jobs:
       - name: Test updated package builds
         run: |
           .github/scripts/test-package.sh kots
-          
-      - name: Test home-manager rebuild
-        run: |
-          # Test that home-manager builds with updated package
-          # Find the correct home configuration name first
-          nix eval --impure --json .#homeConfigurations --apply 'builtins.attrNames' | \
-            jq -r '.[]' | grep "crdant" | head -1 | \
-            xargs -I {} nix build ".#homeConfigurations.{}.activationPackage" --no-link
-          
+
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v7
         with:
@@ -158,9 +150,8 @@ jobs:
             - **Linux**: `${{ needs.calculate-linux-hash.outputs.linux-hash }}`
             
             ### Validation
-            ✅ Package builds successfully on both macOS and Linux  
-            ✅ Installation tests passed on both platforms  
-            ✅ Home manager rebuild test passed  
+            ✅ Package builds successfully on both macOS and Linux
+            ✅ Installation tests passed on both platforms
             ✅ Vendor hashes calculated and verified for both platforms  
             
             ### Next Steps

--- a/.github/workflows/update-kots.yml
+++ b/.github/workflows/update-kots.yml
@@ -24,6 +24,8 @@ jobs:
         
       - name: Check for KOTS updates
         id: check
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           nix-shell -p python3 python3Packages.requests --run "python3 .github/scripts/update-package.py kots"
 

--- a/.github/workflows/update-kots.yml
+++ b/.github/workflows/update-kots.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Check for KOTS updates
         id: check
         run: |
-          python3 .github/scripts/update-package.py kots
+          nix-shell -p python3 python3Packages.requests --run "python3 .github/scripts/update-package.py kots"
 
   calculate-darwin-hash:
     needs: check-update
@@ -52,7 +52,7 @@ jobs:
       - name: Calculate vendor hash for darwin
         id: vendor
         run: |
-          python3 .github/scripts/calculate-go-vendor-hash.py kots ${{ needs.check-update.outputs.new-version }} macos-latest
+          nix-shell -p python3 python3Packages.requests --run "python3 .github/scripts/calculate-go-vendor-hash.py kots ${{ needs.check-update.outputs.new-version }} macos-latest"
 
       - name: Test KOTS installation
         run: |
@@ -83,7 +83,7 @@ jobs:
       - name: Calculate vendor hash for linux
         id: vendor
         run: |
-          python3 .github/scripts/calculate-go-vendor-hash.py kots ${{ needs.check-update.outputs.new-version }} ubuntu-latest
+          nix-shell -p python3 python3Packages.requests --run "python3 .github/scripts/calculate-go-vendor-hash.py kots ${{ needs.check-update.outputs.new-version }} ubuntu-latest"
 
       - name: Test KOTS installation
         run: |

--- a/.github/workflows/update-replicated.yml
+++ b/.github/workflows/update-replicated.yml
@@ -128,15 +128,7 @@ jobs:
       - name: Test updated package builds
         run: |
           .github/scripts/test-package.sh replicated
-          
-      - name: Test home-manager rebuild
-        run: |
-          # Test that home-manager builds with updated package
-          # Find the correct home configuration name first
-          nix eval --impure --json .#homeConfigurations --apply 'builtins.attrNames' | \
-            jq -r '.[]' | grep "crdant" | head -1 | \
-            xargs -I {} nix build ".#homeConfigurations.{}.activationPackage" --no-link
-          
+
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v7
         with:
@@ -158,9 +150,8 @@ jobs:
             - **Linux**: `${{ needs.calculate-linux-hash.outputs.linux-hash }}`
             
             ### Validation
-            ✅ Package builds successfully on both macOS and Linux  
-            ✅ Installation tests passed on both platforms  
-            ✅ Home manager rebuild test passed  
+            ✅ Package builds successfully on both macOS and Linux
+            ✅ Installation tests passed on both platforms
             ✅ Vendor hashes calculated and verified for both platforms  
             
             ### Next Steps

--- a/.github/workflows/update-replicated.yml
+++ b/.github/workflows/update-replicated.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Check for Replicated updates
         id: check
         run: |
-          python3 .github/scripts/update-package.py replicated
+          nix-shell -p python3 python3Packages.requests --run "python3 .github/scripts/update-package.py replicated"
 
   calculate-darwin-hash:
     needs: check-update
@@ -52,7 +52,7 @@ jobs:
       - name: Calculate vendor hash for darwin
         id: vendor
         run: |
-          python3 .github/scripts/calculate-go-vendor-hash.py replicated ${{ needs.check-update.outputs.new-version }} macos-latest
+          nix-shell -p python3 python3Packages.requests --run "python3 .github/scripts/calculate-go-vendor-hash.py replicated ${{ needs.check-update.outputs.new-version }} macos-latest"
 
       - name: Test Replicated installation
         run: |
@@ -83,7 +83,7 @@ jobs:
       - name: Calculate vendor hash for linux
         id: vendor
         run: |
-          python3 .github/scripts/calculate-go-vendor-hash.py replicated ${{ needs.check-update.outputs.new-version }} ubuntu-latest
+          nix-shell -p python3 python3Packages.requests --run "python3 .github/scripts/calculate-go-vendor-hash.py replicated ${{ needs.check-update.outputs.new-version }} ubuntu-latest"
 
       - name: Test Replicated installation
         run: |

--- a/.github/workflows/update-replicated.yml
+++ b/.github/workflows/update-replicated.yml
@@ -24,6 +24,8 @@ jobs:
         
       - name: Check for Replicated updates
         id: check
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           nix-shell -p python3 python3Packages.requests --run "python3 .github/scripts/update-package.py replicated"
 

--- a/.github/workflows/update-sbctl.yml
+++ b/.github/workflows/update-sbctl.yml
@@ -76,15 +76,7 @@ jobs:
         
       - name: Setup Nix cache
         uses: DeterminateSystems/magic-nix-cache-action@main
-        
-      - name: Test home-manager rebuild
-        run: |
-          # Test that home-manager builds with updated package
-          # Find the correct home configuration name first
-          nix eval --impure --json .#homeConfigurations --apply 'builtins.attrNames' | \
-            jq -r '.[]' | grep "crdant" | head -1 | \
-            xargs -I {} nix build ".#homeConfigurations.{}.activationPackage" --no-link
-          
+
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v7
         with:
@@ -106,10 +98,9 @@ jobs:
             - **Linux**: `${{ needs.update-sbctl.outputs.linux-hash }}`
             
             ### Validation
-            ✅ Package builds successfully on Linux  
-            ✅ Package builds successfully on macOS  
-            ✅ Installation tests passed on both platforms  
-            ✅ Home manager rebuild test passed  
+            ✅ Package builds successfully on Linux
+            ✅ Package builds successfully on macOS
+            ✅ Installation tests passed on both platforms
             ✅ Binary hashes calculated and verified for both platforms  
             
             ### Next Steps

--- a/.github/workflows/update-sbctl.yml
+++ b/.github/workflows/update-sbctl.yml
@@ -29,6 +29,8 @@ jobs:
         
       - name: Check for sbctl updates and update package
         id: check
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           nix-shell -p python3 python3Packages.requests --run "python3 .github/scripts/update-package.py sbctl"
           

--- a/.github/workflows/update-sbctl.yml
+++ b/.github/workflows/update-sbctl.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Check for sbctl updates and update package
         id: check
         run: |
-          python3 .github/scripts/update-package.py sbctl
+          nix-shell -p python3 python3Packages.requests --run "python3 .github/scripts/update-package.py sbctl"
           
       - name: Test sbctl installation on Linux
         if: steps.check.outputs.updated == 'true'

--- a/.github/workflows/update-vimr.yml
+++ b/.github/workflows/update-vimr.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Check for VimR updates
         id: check
         run: |
-          python3 .github/scripts/update-package.py vimr
+          nix-shell -p python3 python3Packages.requests --run "python3 .github/scripts/update-package.py vimr"
           
       - name: Test VimR installation
         if: steps.check.outputs.updated == 'true'

--- a/.github/workflows/update-vimr.yml
+++ b/.github/workflows/update-vimr.yml
@@ -23,6 +23,8 @@ jobs:
         
       - name: Check for VimR updates
         id: check
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           nix-shell -p python3 python3Packages.requests --run "python3 .github/scripts/update-package.py vimr"
           

--- a/.github/workflows/update-vimr.yml
+++ b/.github/workflows/update-vimr.yml
@@ -30,16 +30,7 @@ jobs:
         if: steps.check.outputs.updated == 'true'
         run: |
           .github/scripts/test-package.sh vimr
-          
-      - name: Test home-manager rebuild
-        if: steps.check.outputs.updated == 'true'
-        run: |
-          # Test that home-manager builds with updated package
-          # Find the correct home configuration name first
-          nix eval --impure --json .#homeConfigurations --apply 'builtins.attrNames' | \
-            jq -r '.[]' | grep "crdant" | head -1 | \
-            xargs -I {} nix build ".#homeConfigurations.{}.activationPackage" --no-link
-          
+
       - name: Create Pull Request
         if: steps.check.outputs.updated == 'true'
         uses: peter-evans/create-pull-request@v7
@@ -58,9 +49,8 @@ jobs:
             - **Release notes**: https://github.com/qvacua/vimr/releases/tag/${{ steps.check.outputs.new-version }}
             
             ### Validation
-            ✅ Package builds successfully  
+            ✅ Package builds successfully
             ✅ Installation test passed on macOS  
-            ✅ Home manager rebuild test passed  
             
             ### Next Steps
             - Review the changes and ensure they look correct

--- a/pkgs/vimr/default.nix
+++ b/pkgs/vimr/default.nix
@@ -2,12 +2,12 @@
 
 stdenv.mkDerivation rec {
   pname = "vimr";
-  version = "v0.58.0";
-  build = "20251013.211150";
+  version = "v0.59.0";
+  build = "20251103.194245";
 
   src = fetchurl {
     url = "https://github.com/qvacua/vimr/releases/download/${version}-${build}/VimR-${version}.tar.bz2";
-    sha256 = "sha256-5ebQTiDrwTlb7ANh8CCJJIHyd+ONj7T+3Z+HbIfG2X0=";
+    sha256 = "sha256-V6SalfBTvFnWLqRby7mJ1D1o9RUdNxvO43HA9wEeRRM=";
   };
 
   dontFixup = true;


### PR DESCRIPTION
TL;DR
-----

Resolves multiple cascading failures in automated package update workflows by ensuring Python dependencies are available, properly handling VimR's app bundle architecture, authenticating GitHub API requests, and removing unnecessary validation steps.

Details
--------

The automated package update workflows were experiencing systematic failures that prevented successful execution of VimR and other package updates. These issues emerged after recent workflow enhancements and manifested as four distinct but interconnected problems that needed coordinated resolution.

The Python update scripts require the `requests` library to interact with GitHub's API for checking release information, but GitHub Actions runners provide only a minimal Python installation without this module. This caused immediate `ModuleNotFoundError` failures in all package update workflows. The solution wraps Python invocations with `nix-shell -p python3 python3Packages.requests`, ensuring the required dependency is available through Nix rather than relying on system Python packages.

VimR presents unique challenges as a macOS application bundle that installs to `Applications/VimR.app` rather than providing command-line binaries in PATH. The test script was attempting to verify a `vimr` binary existence and failed consistently. The fix adds VimR-specific handling with an empty `BINARY_NAME`, causing the script to skip binary availability checks while still validating the app bundle structure through platform-specific verification.

GitHub API authentication was missing from the update check steps, causing workflows to hit the unauthenticated rate limit of 60 requests per hour almost immediately. By exposing `secrets.GITHUB_TOKEN` to the Python scripts through environment variables, workflows now operate under the authenticated limit of 5000 requests per hour, essentially eliminating rate limit concerns for normal operation.

The home-manager rebuild tests were causing failures due to `builtins.currentSystem` being unavailable in pure evaluation mode, and represented unnecessary validation since package build tests already verify correctness. Per feedback that "we don't need to test the home manager configuration, it's sufficient to test the package", these steps were removed from all workflows, simplifying the validation pipeline and eliminating a fragile test dependency.

All changes maintain consistency across the five affected workflows (VimR, KOTS, Replicated, sbctl, and package status checks), ensuring uniform behavior and maintainability. The VimR workflow successfully executed end-to-end after these fixes, automatically creating PR #211 to update VimR from v0.58.0 to v0.59.0, demonstrating that the automation pipeline now functions reliably.

These fixes enable the automated package update system to operate without manual intervention, supporting the project's goal of keeping dependencies current through GitHub Actions automation rather than manual updates.

Related: PR #211 (VimR v0.59.0 update created by fixed workflow)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * VimR upgraded to v0.59.0

* **Chores**
  * Enhanced package testing framework to support app bundle configurations
  * Improved post-build validation error handling and messaging
  * Streamlined CI/CD workflows for more reliable dependency provisioning
  * Simplified automated testing pipeline by removing redundant verification steps

<!-- end of auto-generated comment: release notes by coderabbit.ai -->