### PR TITLE
Updates flake and refreshes package mix

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -28,11 +28,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1765066094,
-        "narHash": "sha256-0YSU35gfRFJzx/lTGgOt6ubP8K6LeW0vaywzNNqxkl4=",
+        "lastModified": 1767634391,
+        "narHash": "sha256-owcSz2ICqTSvhBbhPP+1eWzi88e54rRZtfCNE5E/wwg=",
         "owner": "lnl7",
         "repo": "nix-darwin",
-        "rev": "688427b1aab9afb478ca07989dc754fa543e03d5",
+        "rev": "08585aacc3d6d6c280a02da195fdbd4b9cf083c2",
         "type": "github"
       },
       "original": {
@@ -70,11 +70,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1767024057,
-        "narHash": "sha256-B1aycRjMRvb6QOGbnqDhiDzZwMebj5jxZ5qyJzaKvpI=",
+        "lastModified": 1767910483,
+        "narHash": "sha256-MOU5YdVu4DVwuT5ztXgQpPuRRBjSjUGIdUzOQr9iQOY=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "34578a2fdfce4257ce5f5baf6e7efbd4e4e252b1",
+        "rev": "82fb7dedaad83e5e279127a38ef410bcfac6d77c",
         "type": "github"
       },
       "original": {
@@ -86,11 +86,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1767173816,
-        "narHash": "sha256-NU4u5NfG00lMrGcfKoH1pX+Kk08DuPTVbaoInH/MBEM=",
+        "lastModified": 1767962478,
+        "narHash": "sha256-7ywwapHmJ2/dtP0j1t9fV9KQc+byL9W9X9oG3aDS4qg=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "16e25e5209b04e1b4d086b2e203ec3848ee18b03",
+        "rev": "35588f29848c57ea8ac86699278d2a410dab0adb",
         "type": "github"
       },
       "original": {
@@ -102,11 +102,11 @@
     },
     "nixpkgs-unstable": {
       "locked": {
-        "lastModified": 1767151656,
-        "narHash": "sha256-ujL2AoYBnJBN262HD95yer7QYUmYp5kFZGYbyCCKxq8=",
+        "lastModified": 1768302833,
+        "narHash": "sha256-h5bRFy9bco+8QcK7rGoOiqMxMbmn21moTACofNLRMP4=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "f665af0cdb70ed27e1bd8f9fdfecaf451260fc55",
+        "rev": "61db79b0c6b838d9894923920b612048e1201926",
         "type": "github"
       },
       "original": {
@@ -118,11 +118,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1766840161,
-        "narHash": "sha256-Ss/LHpJJsng8vz1Pe33RSGIWUOcqM1fjrehjUkdrWio=",
+        "lastModified": 1768032153,
+        "narHash": "sha256-6kD1MdY9fsE6FgSwdnx29hdH2UcBKs3/+JJleMShuJg=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "3edc4a30ed3903fdf6f90c837f961fa6b49582d1",
+        "rev": "3146c6aa9995e7351a398e17470e15305e6e18ff",
         "type": "github"
       },
       "original": {
@@ -140,11 +140,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1767193481,
-        "narHash": "sha256-zxf+RuVtgxpZZA97Sc03tvmfeOXzvBz/wlFDcYb6Zno=",
+        "lastModified": 1768334984,
+        "narHash": "sha256-lc/pGYdBFML8pxYAKCmuBQtHMQ02Ai8B7+Z5mxNtUI8=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "0e7b98891a94ae7c29d319111e3469daa80410f8",
+        "rev": "e181b19377b10a8582f6725e78f90ca9391738b1",
         "type": "github"
       },
       "original": {
@@ -169,11 +169,11 @@
         "nixpkgs": "nixpkgs_2"
       },
       "locked": {
-        "lastModified": 1766894905,
-        "narHash": "sha256-pn8AxxfajqyR/Dmr1wnZYdUXHgM3u6z9x0Z1Ijmz2UQ=",
+        "lastModified": 1768271704,
+        "narHash": "sha256-jJqlW8A3OZ5tYbXphF7U8P8g/3Cn8PPwPa4YlJ/9agg=",
         "owner": "Mic92",
         "repo": "sops-nix",
-        "rev": "61b39c7b657081c2adc91b75dd3ad8a91d6f07a7",
+        "rev": "691b8b6713855d0fe463993867291c158472fc6f",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -70,11 +70,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1767910483,
-        "narHash": "sha256-MOU5YdVu4DVwuT5ztXgQpPuRRBjSjUGIdUzOQr9iQOY=",
+        "lastModified": 1768949235,
+        "narHash": "sha256-TtjKgXyg1lMfh374w5uxutd6Vx2P/hU81aEhTxrO2cg=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "82fb7dedaad83e5e279127a38ef410bcfac6d77c",
+        "rev": "75ed713570ca17427119e7e204ab3590cc3bf2a5",
         "type": "github"
       },
       "original": {
@@ -102,11 +102,11 @@
     },
     "nixpkgs-unstable": {
       "locked": {
-        "lastModified": 1768302833,
-        "narHash": "sha256-h5bRFy9bco+8QcK7rGoOiqMxMbmn21moTACofNLRMP4=",
+        "lastModified": 1768875095,
+        "narHash": "sha256-dYP3DjiL7oIiiq3H65tGIXXIT1Waiadmv93JS0sS+8A=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "61db79b0c6b838d9894923920b612048e1201926",
+        "rev": "ed142ab1b3a092c4d149245d0c4126a5d7ea00b0",
         "type": "github"
       },
       "original": {
@@ -118,11 +118,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1768032153,
-        "narHash": "sha256-6kD1MdY9fsE6FgSwdnx29hdH2UcBKs3/+JJleMShuJg=",
+        "lastModified": 1768569498,
+        "narHash": "sha256-bB6Nt99Cj8Nu5nIUq0GLmpiErIT5KFshMQJGMZwgqUo=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "3146c6aa9995e7351a398e17470e15305e6e18ff",
+        "rev": "be5afa0fcb31f0a96bf9ecba05a516c66fcd8114",
         "type": "github"
       },
       "original": {
@@ -140,11 +140,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1768334984,
-        "narHash": "sha256-lc/pGYdBFML8pxYAKCmuBQtHMQ02Ai8B7+Z5mxNtUI8=",
+        "lastModified": 1769105636,
+        "narHash": "sha256-yAm01w8HsObal4foLMeHzUuU3Gy4c601q8jYNRUFS3c=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "e181b19377b10a8582f6725e78f90ca9391738b1",
+        "rev": "76db60808f29da3139f7b3da215ebff46e64655a",
         "type": "github"
       },
       "original": {
@@ -169,11 +169,11 @@
         "nixpkgs": "nixpkgs_2"
       },
       "locked": {
-        "lastModified": 1768271704,
-        "narHash": "sha256-jJqlW8A3OZ5tYbXphF7U8P8g/3Cn8PPwPa4YlJ/9agg=",
+        "lastModified": 1768863606,
+        "narHash": "sha256-1IHAeS8WtBiEo5XiyJBHOXMzECD6aaIOJmpQKzRRl64=",
         "owner": "Mic92",
         "repo": "sops-nix",
-        "rev": "691b8b6713855d0fe463993867291c158472fc6f",
+        "rev": "c7067be8db2c09ab1884de67ef6c4f693973f4a2",
         "type": "github"
       },
       "original": {

--- a/home/modules/ai/default.nix
+++ b/home/modules/ai/default.nix
@@ -34,6 +34,7 @@ in {
       mbta-mcp-server
       mods
       repomix
+      ttok
     ];
   
  

--- a/home/modules/base/default.nix
+++ b/home/modules/base/default.nix
@@ -50,7 +50,9 @@ in {
       opensc
       procps
       yq-go
-    ];
+    ] ++ lib.optionals isDarwin [
+      icalpal
+    ]
 
     file = {
       ".curlrc" = {

--- a/home/modules/base/default.nix
+++ b/home/modules/base/default.nix
@@ -52,7 +52,7 @@ in {
       yq-go
     ] ++ lib.optionals isDarwin [
       icalpal
-    ]
+    ];
 
     file = {
       ".curlrc" = {

--- a/home/modules/infrastructure/default.nix
+++ b/home/modules/infrastructure/default.nix
@@ -11,6 +11,7 @@ in {
       leftovers
       packer
       restic
+      talosctl
       terraform
       terraform-lsp
       vault

--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -19,4 +19,6 @@ rec {
   instruqt = pkgs.callPackage ./instruqt { };
 
   imgpkg = pkgs.callPackage ./imgpkg { };
+
+  icalpal = pkgs.callPackage ./icalpal { };
 }

--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -21,4 +21,6 @@ rec {
   imgpkg = pkgs.callPackage ./imgpkg { };
 
   icalpal = pkgs.callPackage ./icalpal { };
+
+  ttok = pkgs.callPackage ./ttok { };
 }

--- a/pkgs/icalpal/Gemfile
+++ b/pkgs/icalpal/Gemfile
@@ -1,0 +1,11 @@
+source 'https://rubygems.org'
+
+# Dependencies for icalPal (the gem itself is installed from source)
+gem 'plist'
+gem 'sqlite3'
+gem 'mini_portile2'  # dependency of sqlite3
+gem 'logger'
+gem 'csv'
+gem 'json'
+gem 'rdoc'
+gem 'psych'  # provides yaml

--- a/pkgs/icalpal/Gemfile.lock
+++ b/pkgs/icalpal/Gemfile.lock
@@ -1,0 +1,57 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    csv (3.3.5)
+    date (3.5.1)
+    erb (6.0.1)
+    json (2.18.0)
+    logger (1.7.0)
+    mini_portile2 (2.8.9)
+    plist (3.7.2)
+    psych (5.3.1)
+      date
+      stringio
+    rdoc (7.1.0)
+      erb
+      psych (>= 4.0.0)
+      tsort
+    sqlite3 (2.9.0)
+      mini_portile2 (~> 2.8.0)
+    sqlite3 (2.9.0-aarch64-linux-gnu)
+    sqlite3 (2.9.0-aarch64-linux-musl)
+    sqlite3 (2.9.0-arm-linux-gnu)
+    sqlite3 (2.9.0-arm-linux-musl)
+    sqlite3 (2.9.0-arm64-darwin)
+    sqlite3 (2.9.0-x86-linux-gnu)
+    sqlite3 (2.9.0-x86-linux-musl)
+    sqlite3 (2.9.0-x86_64-darwin)
+    sqlite3 (2.9.0-x86_64-linux-gnu)
+    sqlite3 (2.9.0-x86_64-linux-musl)
+    stringio (3.2.0)
+    tsort (0.2.0)
+
+PLATFORMS
+  aarch64-linux-gnu
+  aarch64-linux-musl
+  arm-linux-gnu
+  arm-linux-musl
+  arm64-darwin
+  ruby
+  x86-linux-gnu
+  x86-linux-musl
+  x86_64-darwin
+  x86_64-linux-gnu
+  x86_64-linux-musl
+
+DEPENDENCIES
+  csv
+  json
+  logger
+  mini_portile2
+  plist
+  psych
+  rdoc
+  sqlite3
+
+BUNDLED WITH
+   2.7.2

--- a/pkgs/icalpal/default.nix
+++ b/pkgs/icalpal/default.nix
@@ -1,0 +1,70 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, ruby
+, bundlerEnv
+, libyaml
+, sqlite
+, makeWrapper
+}:
+
+let
+  version = "4.1.1";
+
+  # Create a bundler environment with all the dependencies pre-installed
+  gems = bundlerEnv {
+    name = "icalpal-gems-${version}";
+    inherit ruby;
+    gemdir = ./.;
+    gemConfig = {
+      psych = attrs: {
+        buildInputs = [ libyaml ];
+      };
+      sqlite3 = attrs: {
+        buildInputs = [ sqlite ];
+        buildFlags = [ "--enable-system-libraries" ];
+      };
+    };
+  };
+in
+stdenv.mkDerivation {
+  pname = "icalpal";
+  inherit version;
+
+  src = fetchFromGitHub {
+    owner = "ajrosen";
+    repo = "icalPal";
+    rev = "icalPal-${version}";
+    hash = "sha256-NWFXnp06ln5JOc08U4ZVFrSBijmNamKbUj0Djo9c8ZQ=";
+  };
+
+  nativeBuildInputs = [ makeWrapper ];
+  buildInputs = [ gems ruby ];
+
+  dontBuild = true;
+
+  installPhase = ''
+    runHook preInstall
+
+    # Install in the structure expected by the script
+    # bin/icalPal expects ../lib/ to contain the ruby files
+    mkdir -p $out/share/icalpal/bin $out/share/icalpal/lib $out/bin
+    cp bin/icalPal $out/share/icalpal/bin/
+    cp lib/*.rb $out/share/icalpal/lib/
+
+    # Create wrapper that sets up the gem path
+    makeWrapper ${ruby}/bin/ruby $out/bin/icalPal \
+      --set GEM_PATH "${gems}/lib/ruby/gems/${ruby.version.libDir}" \
+      --add-flags "$out/share/icalpal/bin/icalPal"
+
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "Command-line tool to query macOS Calendar and Reminders";
+    homepage = "https://github.com/ajrosen/icalPal";
+    license = licenses.gpl3Plus;
+    platforms = platforms.darwin;
+    mainProgram = "icalPal";
+  };
+}

--- a/pkgs/icalpal/gemset.nix
+++ b/pkgs/icalpal/gemset.nix
@@ -1,0 +1,125 @@
+{
+  csv = {
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0gz7r2kazwwwyrwi95hbnhy54kwkfac5swh2gy5p5vw36fn38lbf";
+      type = "gem";
+    };
+    version = "3.3.5";
+  };
+  date = {
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1h0db8r2v5llxdbzkzyllkfniqw9gm092qn7cbaib73v9lw0c3bm";
+      type = "gem";
+    };
+    version = "3.5.1";
+  };
+  erb = {
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1rcpq49pyaiclpjp3c3qjl25r95hqvin2q2dczaynaj7qncxvv18";
+      type = "gem";
+    };
+    version = "6.0.1";
+  };
+  json = {
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "01fmiz052cvnxgdnhb3qwcy88xbv7l3liz0fkvs5qgqqwjp0c1di";
+      type = "gem";
+    };
+    version = "2.18.0";
+  };
+  logger = {
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "00q2zznygpbls8asz5knjvvj2brr3ghmqxgr83xnrdj4rk3xwvhr";
+      type = "gem";
+    };
+    version = "1.7.0";
+  };
+  mini_portile2 = {
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "12f2830x7pq3kj0v8nz0zjvaw02sv01bqs1zwdrc04704kwcgmqc";
+      type = "gem";
+    };
+    version = "2.8.9";
+  };
+  plist = {
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0hlaf4b3d8grxm9fqbnam5gwd55wvghl0jyzjd1hc5hirhklaynk";
+      type = "gem";
+    };
+    version = "3.7.2";
+  };
+  psych = {
+    dependencies = ["date" "stringio"];
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0x0r3gc66abv8i4dw0x0370b5hrshjfp6kpp7wbp178cy775fypb";
+      type = "gem";
+    };
+    version = "5.3.1";
+  };
+  rdoc = {
+    dependencies = ["erb" "psych" "tsort"];
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0qvky4s2fx5xbaz1brxanalqbcky3c7xbqd6dicpih860zgrjj29";
+      type = "gem";
+    };
+    version = "7.1.0";
+  };
+  sqlite3 = {
+    dependencies = ["mini_portile2"];
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0v19bypbf46ms3gvk47hi4smcf6pm0gc8daa786mapzc685w1sgc";
+      type = "gem";
+    };
+    version = "2.9.0";
+  };
+  stringio = {
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1q92y9627yisykyscv0bdsrrgyaajc2qr56dwlzx7ysgigjv4z63";
+      type = "gem";
+    };
+    version = "3.2.0";
+  };
+  tsort = {
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "17q8h020dw73wjmql50lqw5ddsngg67jfw8ncjv476l5ys9sfl4n";
+      type = "gem";
+    };
+    version = "0.2.0";
+  };
+}

--- a/pkgs/ttok/default.nix
+++ b/pkgs/ttok/default.nix
@@ -1,0 +1,41 @@
+# ./ttok/default.nix
+{
+  lib,
+  python3,
+  fetchFromGitHub,
+}:
+
+python3.pkgs.buildPythonPackage rec {
+  pname = "ttok";
+  version = "0.3";
+
+  pyproject = true;
+  build-system = [
+    python3.pkgs.setuptools
+  ];
+
+  src = fetchFromGitHub {
+    owner = "simonw";
+    repo = "ttok";
+    rev = version;
+    sha256 = "sha256-I6EPE6GDAiDM+FbxYzRW4Pml0wDA2wNP1y3pD3dg7Gg=";
+  };
+
+  propagatedBuildInputs = with python3.pkgs; [
+    click
+    tiktoken
+  ];
+
+  nativeCheckInputs = with python3.pkgs; [
+    pytest
+  ];
+
+  pythonImportsCheck = [ "ttok" ];
+
+  meta = with lib; {
+    description = "Count and truncate text based on tokens";
+    homepage = "https://github.com/simonw/ttok";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ ];
+  };
+}

--- a/systems/modules/desktop/default.nix
+++ b/systems/modules/desktop/default.nix
@@ -14,11 +14,6 @@ let
         upgrade = true;
       };
       
-      taps = [
-        "OJFord/formulae"
-        "vmware-tanzu/carvel"
-      ];
-
       casks = [
         "font-cabin"
         "font-noto-sans"
@@ -35,7 +30,6 @@ let
        # "1Blocker" = 1365531024;
        "1Password for Safari" = 1569813296;
        "Amphetamine" = 937984704;
-       "Bear" = 1091189122;
        "Keynote" = 409183694;
        "Microsoft Excel" = 462058435;
        "Microsoft PowerPoint" = 462062816;


### PR DESCRIPTION
TL;DR
-----

Updates flake inputs to newer versions, expands available development tools and streamlines package mix

Details
--------

Keps up-to-date and makes some minor improvements:

* Adds `icalpal` for use with Claude Code
* Creates a package for `ttok` and includes it in the AI home manager module
* Ceases installing Bear now that I'm all in with Obsidian
* Installs `talosctl` with the home manager infrastructure module since I'm using it for some clusters


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added ttok, icalpal, and talosctl tools across AI, base, and infrastructure modules.

* **Chores**
  * Removed OJFord/formulae and vmware-tanzu/carvel Homebrew taps.
  * Removed Bear app from automated App Store installation.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->