### PR TITLE
Adds claude-code-transcripts tool

### DIFF
--- a/home/modules/ai/default.nix
+++ b/home/modules/ai/default.nix
@@ -11,6 +11,7 @@ in {
       amp-cli
       ollama
       nur.repos.charmbracelet.crush
+      claude-code-transcripts
       unstable.claude-code
       unstable.fabric-ai
       gemini-cli

--- a/pkgs/claude-code-transcripts/default.nix
+++ b/pkgs/claude-code-transcripts/default.nix
@@ -1,0 +1,44 @@
+{
+  lib,
+  python3,
+  fetchFromGitHub,
+}:
+
+python3.pkgs.buildPythonPackage rec {
+  pname = "claude-code-transcripts";
+  version = "0.6";
+
+  pyproject = true;
+  build-system = [
+    python3.pkgs.uv-build
+  ];
+
+  src = fetchFromGitHub {
+    owner = "simonw";
+    repo = "claude-code-transcripts";
+    rev = version;
+    hash = "sha256-MCs8B00K/D4rO4kWi3PlATo44rvBlQWYF7gU2c5tFrk=";
+  };
+
+  propagatedBuildInputs = with python3.pkgs; [
+    click
+    click-default-group
+    httpx
+    jinja2
+    markdown
+    questionary
+  ];
+
+  nativeCheckInputs = with python3.pkgs; [
+    pytest
+  ];
+
+  pythonImportsCheck = [ "claude_code_transcripts" ];
+
+  meta = with lib; {
+    description = "Convert Claude Code session files to HTML transcripts";
+    homepage = "https://github.com/simonw/claude-code-transcripts";
+    license = licenses.asl20;
+    mainProgram = "claude-code-transcripts";
+  };
+}

--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -23,6 +23,7 @@ rec {
   icalpal = pkgs.callPackage ./icalpal { };
 
   # simonw tools
+  claude-code-transcripts = pkgs.callPackage ./claude-code-transcripts { };
   ttok = pkgs.callPackage ./ttok { };
   rodney = pkgs.callPackage ./rodney { };
   showboat = pkgs.callPackage ./showboat { };


### PR DESCRIPTION
TL;DR
------
Packages simonw's claude-code-transcripts as a Nix derivation and
installs it via the AI home-manager module.

Details
-------
Converts Claude Code session files into browsable HTML transcripts,
making it easier to review and share coding sessions outside the
terminal.

Builds the Python package from source using the existing custom
package pattern alongside other simonw tools (ttok, rodney, showboat).
Uses uv-build as the build system to match upstream's pyproject.toml.

Installs through the AI module since the tool operates directly on
Claude Code session data.

🤖 Generated with [Claude Code](https://claude.com/claude-code)