### PR TITLE
Fixes race condition between sops-nix and MCP servers activation

### DIFF
--- a/home/modules/ai/default.nix
+++ b/home/modules/ai/default.nix
@@ -68,9 +68,23 @@ in {
         fi
       '';
 
+      # Ensure sops template target directories exist
+      claudeDataDir = lib.hm.dag.entryBefore [ "sops-nix" ] ''
+        $DRY_RUN_CMD mkdir -p ${config.xdg.dataHome}/claude
+      '';
+
       # Update mcpServers in Claude config files
       claudeMcpServers = lib.hm.dag.entryAfter [ "sops-nix" ] (''
-        MCP_SERVERS="$(cat ${config.sops.templates."mcp-servers.json".path})"
+        MCP_SERVERS_FILE="${config.sops.templates."mcp-servers.json".path}"
+
+        # sops-nix on macOS renders templates via an async LaunchAgent;
+        # wait for it to finish before reading
+        for _attempt in $(seq 1 30); do
+          [ -r "$MCP_SERVERS_FILE" ] && break
+          sleep 1
+        done
+
+        MCP_SERVERS="$(cat "$MCP_SERVERS_FILE")"
 
         if [ -n "$MCP_SERVERS" ]; then
           for CONFIG_DIR in ${config.xdg.configHome}/claude/replicated ${config.xdg.configHome}/claude/personal ; do


### PR DESCRIPTION
## Summary

- On macOS, sops-nix renders templates via an async LaunchAgent. The `claudeMcpServers` activation script was reading the rendered template immediately after sops-nix bootstrapped the agent, before it finished writing. This caused `cat: No such file or directory` on the broken symlink target.
- Adds `claudeDataDir` to create `~/.local/share/claude/` before sops-nix runs (needed for first-run symlink creation)
- Adds a wait loop in `claudeMcpServers` for the LaunchAgent to finish rendering before reading

## Test plan

- [x] Deleted rendered `mcp-servers.json` to simulate race condition, ran `make user` — wait loop caught it, activation succeeded
- [x] Ran `make user` again — idempotent, no delay since file already exists
- [x] Verified MCP servers template renders with correct secret values

🤖 Generated with [Claude Code](https://claude.com/claude-code)