### PR TITLE
Adds Apple container runtime

### DIFF
--- a/home/modules/containers/default.nix
+++ b/home/modules/containers/default.nix
@@ -17,6 +17,7 @@ in {
     skopeo
     trivy
   ] ++ lib.optionals isDarwin [
+    container
     unstable.colima
   ] ++ lib.optionals isLinux [
     nerdctl

--- a/overlays/default.nix
+++ b/overlays/default.nix
@@ -9,6 +9,14 @@
   modifications = final: prev: {
     mas = final.unstable.mas;
 
+    container = prev.container.overrideAttrs (oldAttrs: rec {
+      version = "0.10.0";
+      src = prev.fetchurl {
+        url = "https://github.com/apple/container/releases/download/${version}/container-${version}-installer-signed.pkg";
+        hash = "sha256-xIHONVUk0DbDzdrH/SgeMXlNQGkL+aIfcy7z12+p/gg=";
+      };
+    });
+
     vimPlugins = prev.vimPlugins // {
       nvim-aider = prev.callPackage ./nvim-aider { };
       # xcodebuild-nvim = prev.callPackage ./xcodebuild-nvim { }; 


### PR DESCRIPTION
## TL;DR

Adds Apple's `container` CLI to the containers home manager module as a darwin-only package, overlaid to v0.10.0.

## Details

Overlays the nixpkgs `container` package from v0.6.0 to v0.10.0 to pick up a kernel panic fix under load, container export support, multiple network plugin support, and additional CLI flags (`--init-image`, `--runtime`, `--pull`). Adds the package to the darwin-only section of the containers module alongside colima.

Uses `overrideAttrs` in the modifications overlay rather than a custom package derivation, since upstream nixpkgs already handles extraction of the signed `.pkg` installer and shell completion generation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)