### PR TITLE
Add luca and dewey users to pisco

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -36,7 +36,10 @@
       };
 
       # Helper function to create home configurations with profiles
-      mkHomeConfig = { username, homeDirectory, gitEmail, profile ? "full", homeModule ? ./home/users/crdant/home.nix }:
+      mkHomeConfig = { username, gitEmail, profile ? "full"
+        , homeDirectory ? (if isDarwin then "/Users/${username}" else "/home/${username}")
+        , homeModule ? (./. + "/home/users/${username}/home.nix")
+      }:
         home-manager.lib.homeManagerConfiguration {
           inherit pkgs;
           extraSpecialArgs = {inherit inputs outputs username homeDirectory gitEmail profile;};
@@ -106,22 +109,17 @@
           # User configurations with different profiles
           userConfigs = {
             chuck = {
-              homeDirectory = if isDarwin then "/Users/chuck" else "/home/chuck";
               gitEmail = "chuck@replicated.com";
+              homeModule = ./home/users/crdant/home.nix;
             };
             crdant = {
-              homeDirectory = if isDarwin then "/Users/crdant" else "/home/crdant";
               gitEmail = "chuck@crdant.io";
             };
             luca = {
-              homeDirectory = if isDarwin then "/Users/luca" else "/home/luca";
               gitEmail = "";
-              homeModule = ./home/users/luca/home.nix;
             };
             dewey = {
-              homeDirectory = if isDarwin then "/Users/dewey" else "/home/dewey";
               gitEmail = "";
-              homeModule = ./home/users/dewey/home.nix;
             };
           };
           
@@ -136,10 +134,7 @@
                   let userConfig = userConfigs.${username}; in
                   builtins.map (profile: {
                     name = if profile == "full" then username else "${username}:${profile}";
-                    value = mkHomeConfig ({
-                      inherit username profile;
-                      inherit (userConfig) homeDirectory gitEmail;
-                    } // (if userConfig ? homeModule then { inherit (userConfig) homeModule; } else {}));
+                    value = mkHomeConfig ({ inherit username profile; } // userConfig);
                   }) profiles
                 ) (builtins.attrNames userConfigs)
               )

--- a/flake.nix
+++ b/flake.nix
@@ -36,12 +36,12 @@
       };
 
       # Helper function to create home configurations with profiles
-      mkHomeConfig = { username, homeDirectory, gitEmail, profile ? "full" }: 
+      mkHomeConfig = { username, homeDirectory, gitEmail, profile ? "full", homeModule ? ./home/users/crdant/home.nix }:
         home-manager.lib.homeManagerConfiguration {
           inherit pkgs;
           extraSpecialArgs = {inherit inputs outputs username homeDirectory gitEmail profile;};
-          modules = [ 
-            ./home/users/crdant/home.nix
+          modules = [
+            homeModule
           ];
         };
     in {
@@ -91,10 +91,12 @@
         "pisco" = darwin.lib.darwinSystem {
           system = "aarch64-darwin";
           specialArgs = {inherit inputs outputs;};
-          modules = [ 
+          modules = [
             ./systems/hosts/pisco/default.nix
             ./home/users/crdant/crdant.nix
             ./home/users/crdant/darwin.nix
+            ./home/users/luca/luca.nix
+            ./home/users/dewey/dewey.nix
           ];
         };
       }; 
@@ -111,6 +113,16 @@
               homeDirectory = if isDarwin then "/Users/crdant" else "/home/crdant";
               gitEmail = "chuck@crdant.io";
             };
+            luca = {
+              homeDirectory = if isDarwin then "/Users/luca" else "/home/luca";
+              gitEmail = "";
+              homeModule = ./home/users/luca/home.nix;
+            };
+            dewey = {
+              homeDirectory = if isDarwin then "/Users/dewey" else "/home/dewey";
+              gitEmail = "";
+              homeModule = ./home/users/dewey/home.nix;
+            };
           };
           
           # Available profiles
@@ -120,14 +132,14 @@
           generateConfigs = userConfigs: profiles:
             builtins.listToAttrs (
               builtins.concatLists (
-                builtins.map (username: 
+                builtins.map (username:
                   let userConfig = userConfigs.${username}; in
                   builtins.map (profile: {
                     name = if profile == "full" then username else "${username}:${profile}";
-                    value = mkHomeConfig {
+                    value = mkHomeConfig ({
                       inherit username profile;
                       inherit (userConfig) homeDirectory gitEmail;
-                    };
+                    } // (if userConfig ? homeModule then { inherit (userConfig) homeModule; } else {}));
                   }) profiles
                 ) (builtins.attrNames userConfigs)
               )

--- a/home/users/dewey/dewey.nix
+++ b/home/users/dewey/dewey.nix
@@ -1,0 +1,21 @@
+{ inputs, pkgs, lib, ... }:
+
+let
+  isDarwin = pkgs.stdenv.isDarwin;
+  isLinux = pkgs.stdenv.isLinux;
+in
+{
+  users.users.dewey = {
+    home = if isDarwin then
+      "/Users/dewey"
+    else
+      "/home/dewey";
+
+    shell = pkgs.zsh;
+    description = "Dewey";
+  } // lib.optionalAttrs isLinux {
+    isNormalUser = true;
+    group = "dewey";
+    extraGroups = [ "adm" "sudo" "wheel" ];
+  };
+}

--- a/home/users/dewey/home.nix
+++ b/home/users/dewey/home.nix
@@ -1,0 +1,7 @@
+{ inputs, outputs, config, pkgs, lib, username, homeDirectory, gitEmail, profile, ... }:
+
+{
+  imports = [
+    ../../profiles/${profile}.nix
+  ];
+}

--- a/home/users/luca/home.nix
+++ b/home/users/luca/home.nix
@@ -1,0 +1,7 @@
+{ inputs, outputs, config, pkgs, lib, username, homeDirectory, gitEmail, profile, ... }:
+
+{
+  imports = [
+    ../../profiles/${profile}.nix
+  ];
+}

--- a/home/users/luca/luca.nix
+++ b/home/users/luca/luca.nix
@@ -1,0 +1,21 @@
+{ inputs, pkgs, lib, ... }:
+
+let
+  isDarwin = pkgs.stdenv.isDarwin;
+  isLinux = pkgs.stdenv.isLinux;
+in
+{
+  users.users.luca = {
+    home = if isDarwin then
+      "/Users/luca"
+    else
+      "/home/luca";
+
+    shell = pkgs.zsh;
+    description = "Luca";
+  } // lib.optionalAttrs isLinux {
+    isNormalUser = true;
+    group = "luca";
+    extraGroups = [ "adm" "sudo" "wheel" ];
+  };
+}


### PR DESCRIPTION
TL;DR
-----

Adds two new users (`luca` and `dewey`) to the `pisco` host with minimal home profiles.

Details
-------

Creates system-level nix-darwin user definitions and home-manager entry points for each user. Both users get zsh as their default shell and platform-appropriate home directories. Their home-manager configs use the minimal profile (base module only) and omit secrets, keeping the footprint small.

Makes `mkHomeConfig` accept an optional `homeModule` parameter so per-user `home.nix` files can diverge from crdant's (which includes a secrets reference). The `generateConfigs` helper passes `homeModule` through when present in the user config, falling back to crdant's `home.nix` for backward compatibility.

Git email is left empty for both users — fill in if they will use git.

🤖 Generated with [Claude Code](https://claude.com/claude-code)