### PR TITLE
Adds Mole package for macOS deep uninstall

### DIFF
--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -21,6 +21,7 @@ rec {
   imgpkg = pkgs.callPackage ./imgpkg { };
 
   icalpal = pkgs.callPackage ./icalpal { };
+  mole = pkgs.callPackage ./mole { };
 
   zapier-platform-cli = pkgs.callPackage ./zapier-platform-cli { };
 

--- a/pkgs/mole/default.nix
+++ b/pkgs/mole/default.nix
@@ -1,0 +1,53 @@
+{ stdenv, lib, buildGoModule, fetchFromGitHub }:
+
+buildGoModule rec {
+  pname = "mole";
+  version = "1.31.0";
+
+  src = fetchFromGitHub {
+    owner = "tw93";
+    repo = "Mole";
+    rev = "V${version}";
+    sha256 = "sha256-dalmW3W/seGZreSWuYP7JN/nMUbs3WyDHzKU83EveeY=";
+  };
+
+  vendorHash = "sha256-LznLZ0NO8VBWP95ReAVORUMIDhh7/pgTY5mGNN2tND8=";
+
+  postInstall = ''
+    # Create the libexec directory structure
+    mkdir -p $out/libexec/mole/bin
+
+    # Install the main shell scripts
+    install -Dm755 $src/mole $out/libexec/mole/mole
+    install -Dm755 $src/mo $out/libexec/mole/mo
+
+    # Copy the library directory
+    cp -r $src/lib $out/libexec/mole/
+
+    # Copy the bin shell scripts
+    for f in $src/bin/*.sh; do
+      install -Dm755 "$f" "$out/libexec/mole/bin/$(basename "$f")"
+    done
+
+    # Copy Go binaries to the mole bin directory so scripts can find them
+    cp $out/bin/analyze $out/libexec/mole/bin/
+    cp $out/bin/status $out/libexec/mole/bin/
+
+    # Create wrapper scripts in bin
+    rm -f $out/bin/analyze $out/bin/status
+    cat > $out/bin/mo << 'EOF'
+#!/usr/bin/env bash
+exec "@out@/libexec/mole/mole" "$@"
+EOF
+    chmod +x $out/bin/mo
+    substituteInPlace $out/bin/mo --replace-fail '@out@' "$out"
+  '';
+
+  meta = with lib; {
+    homepage = "https://github.com/tw93/Mole";
+    description = "A macOS deep uninstaller for thorough app removal";
+    mainProgram = "mo";
+    license = licenses.mit;
+    platforms = platforms.darwin;
+  };
+}

--- a/systems/modules/essential-packages/default.nix
+++ b/systems/modules/essential-packages/default.nix
@@ -42,6 +42,7 @@ in (lib.mkMerge [
         mas
         m-cli
         darwin.trash
+        mole
       ] ++ lib.optionals isLinux [
         unixtools.watch
       ];


### PR DESCRIPTION
TL;DR
-----

Adds the Mole CLI tool as a custom Nix package and includes it in the essential-packages module for Darwin systems.

Details
-------

Packages [Mole](https://github.com/tw93/Mole), a macOS utility for thorough app removal and system optimization. Provides commands for deep cleaning disk space, complete app uninstallation, system optimization checks, disk usage analysis, and system health monitoring via the `mo` CLI.

Uses `buildGoModule` to compile the Go binaries (`analyze` and `status`), then installs the upstream shell scripts (`mole` and `mo`) alongside them in a `libexec` directory structure. Creates a wrapper script in `bin/mo` that delegates to the main `mole` script, preserving the upstream CLI interface.

Adds the package to the darwin-only section of `systems/modules/essential-packages/default.nix` alongside other macOS utilities like `mas`, `m-cli`, and `darwin.trash`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)