### PR TITLE
Updates dock configuration

### DIFF
--- a/home/modules/desktop/default.nix
+++ b/home/modules/desktop/default.nix
@@ -87,10 +87,10 @@ in {
       ${pkgs.dockutil}/bin/dockutil --add "${pkgs.slack}/Applications/Slack.app" --no-restart
       ${pkgs.dockutil}/bin/dockutil --add "/Applications/Superhuman.app" --no-restart
       ${pkgs.dockutil}/bin/dockutil --add "${pkgs.zoom-us}/Applications/zoom.us.app" --no-restart
-      ${pkgs.dockutil}/bin/dockutil --add "/Applications/X.app" --no-restart
 
       # System applications
       ${pkgs.dockutil}/bin/dockutil --add "/System/Applications/Messages.app" --no-restart
+      ${pkgs.dockutil}/bin/dockutil --add "/Applications/Beeper.app" --no-restart
       ${pkgs.dockutil}/bin/dockutil --add "/System/Applications/Contacts.app" --no-restart
 
       # Productivity apps


### PR DESCRIPTION
TL;DR
-----

Updates the macOS Dock layout to remove X and add Beeper.

Details
-------

Drops X from the third-party apps section — no longer in regular use. Adds Beeper after Messages in the system applications group so both messaging clients sit together for quick access. Keeps Obsidian in its existing position after Todoist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)