### PR TITLE
Fixes GPG pinentry for SSH sessions

### DIFF
--- a/home/modules/ai/default.nix
+++ b/home/modules/ai/default.nix
@@ -70,9 +70,14 @@ in {
 
       # Update mcpServers in Claude config files
       claudeMcpServers = lib.hm.dag.entryAfter [ "sops-nix" ] (''
-        MCP_SERVERS="$(cat ${config.sops.templates."mcp-servers.json".path})"
+        MCP_SERVERS_FILE="${config.sops.templates."mcp-servers.json".path}"
+        if [ ! -f "$MCP_SERVERS_FILE" ]; then
+          echo "MCP servers file not found at $MCP_SERVERS_FILE, skipping mcpServers configuration"
+        else
+          MCP_SERVERS="$(cat "$MCP_SERVERS_FILE")"
+        fi
 
-        if [ -n "$MCP_SERVERS" ]; then
+        if [ -n "''${MCP_SERVERS:-}" ]; then
           for CONFIG_DIR in ${config.xdg.configHome}/claude/replicated ${config.xdg.configHome}/claude/personal ; do
             CONFIG="$CONFIG_DIR/.claude.json"
             [ -f "$CONFIG" ] || echo '{}' > "$CONFIG"

--- a/home/modules/security/gpg-agent.nix
+++ b/home/modules/security/gpg-agent.nix
@@ -20,6 +20,10 @@ in {
       initExtra = ''
         if [[ -z $SSH_TTY ]]; then
           plugins+=( gpg-agent )
+        else
+          # When SSHed in, set GPG_TTY so pinentry-mac can fall back to curses mode
+          export GPG_TTY=$(tty)
+          gpg-connect-agent updatestartuptty /bye >/dev/null 2>&1
         fi
 
         source $ZSH/oh-my-zsh.sh


### PR DESCRIPTION
## Summary
- Sets `GPG_TTY` and updates gpg-agent when in SSH sessions so `pinentry-mac` can fall back to curses mode
- Adds graceful handling when sops MCP servers template file doesn't exist (prevents activation failure when pinentry can't prompt)

## Test plan
- [ ] SSH into a machine with this config
- [ ] Run `make user` - should complete without pinentry errors
- [ ] Verify GPG operations prompt in terminal (curses mode)

🤖 Generated with [Claude Code](https://claude.com/claude-code)