### PR TITLE
Fixes GPG pinentry for SSH sessions

### DIFF
--- a/home/modules/security/gpg-agent.nix
+++ b/home/modules/security/gpg-agent.nix
@@ -20,6 +20,10 @@ in {
       initExtra = ''
         if [[ -z $SSH_TTY ]]; then
           plugins+=( gpg-agent )
+        else
+          # When SSHed in, set GPG_TTY so pinentry-mac can fall back to curses mode
+          export GPG_TTY=$(tty)
+          gpg-connect-agent updatestartuptty /bye >/dev/null 2>&1
         fi
 
         source $ZSH/oh-my-zsh.sh


### PR DESCRIPTION
TL;DR
-----

Enables GPG passphrase prompts over SSH by setting `GPG_TTY` and refreshing the agent's TTY awareness when `SSH_TTY` is present.

Details
-------

Adds an `else` branch to the existing `SSH_TTY` check in `gpg-agent.nix`. When not in an SSH session, the oh-my-zsh `gpg-agent` plugin loads and handles `GPG_TTY`. When SSHed in, the plugin is skipped (to avoid conflicts), but `GPG_TTY` was left unset—causing `pinentry-mac` to fail silently instead of falling back to curses mode.

Sets `GPG_TTY=$(tty)` and runs `gpg-connect-agent updatestartuptty` so the running agent knows which terminal to use for passphrase prompts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)