### PR TITLE
Fixes deprecated Nix evaluation warnings

### DIFF
--- a/home/modules/base/default.nix
+++ b/home/modules/base/default.nix
@@ -211,71 +211,80 @@ in {
         lsock = "sudo /usr/sbin/lsof -i -P";
       };
       
-      initExtra = ''
-        setopt vi
-        setopt nobeep
-        setopt inc_append_history
-        setopt auto_cd
-        setopt bash_auto_list
-        setopt no_hup
-        setopt correct
-        setopt no_always_last_prompt
-        setopt complete_aliases
-        unsetopt hist_verify
+      initContent = lib.mkMerge [
+        # Completion paths - before compinit
+        (lib.mkOrder 550 ''
+          fpath+=($HOME/workspace/oh-my-zsh-custom/completions)
+        '')
 
-        # handle SSH differences between Prompt on iOS and a machine with Yubikey PGP available
-        # if we're connected via a traditional SSH agent it's probably Prompt
-        GPG_AGENT_SSH_SOCK=$(gpgconf --list-dirs agent-ssh-socket)
-	      if [[ -n "$SSH_AUTH_SOCK" && "$SSH_AUTH_SOCK" != "$GPG_AGENT_SSH_SOCK" && $(readlink -f $SSH_AUTH_SOCK) != $GPG_AGENT_SSH_SOCK ]]; then
-          # use ssh signing with the provided key
-          export GIT_CONFIG_COUNT=3
-          export GIT_CONFIG_KEY_0=gpg.format
-          export GIT_CONFIG_VALUE_0=ssh
-          export GIT_CONFIG_KEY_1=user.signingkey
-          export GIT_CONFIG_VALUE_1=~/.ssh/id_charanda_enclave.pub
-          export GIT_CONFIG_KEY_2=gpg.ssh.allowedSignersFile
-          export GIT_CONFIG_VALUE_2=~/.config/git/allowed-signers
-        else
-          if [[ -z "$SSH_AUTH_SOCK" ]]; then
-            export SSH_AUTH_SOCK="$GPG_AGENT_SSH_SOCK"
-          fi
-        fi
+        # Shell options
+        (lib.mkOrder 600 ''
+          setopt vi
+          setopt nobeep
+          setopt inc_append_history
+          setopt auto_cd
+          setopt bash_auto_list
+          setopt no_hup
+          setopt correct
+          setopt no_always_last_prompt
+          setopt complete_aliases
+          unsetopt hist_verify
+        '')
 
-        # Tmux convenience functions
-        function tmux-has-session() { 
-          session=$1
-          tmux has-session -t $session 2>/dev/null 
-        }
-
-        function smug-session() {
-          session=$1
-
-          if [[ ! -d "$XDG_RUNTIME_DIR/ssh" ]]; then
-            mkdir -p "$XDG_RUNTIME_DIR/ssh"
-          fi
-          if [[ "SSH_AUTH_SOCK" != "$XDG_RUNTIME_DIR/ssh/s.ssh-agent.smug-$session" ]]; then
-            ln -sf $(readlink -f $SSH_AUTH_SOCK) "$XDG_RUNTIME_DIR/ssh/s.ssh-agent.smug-$session"
-            export SSH_AUTH_SOCK="$XDG_RUNTIME_DIR/ssh/s.ssh-agent.smug-$session"
-          fi
-          if [[ -f $(pwd)/.smug.yml ]]; then
-            smug start 
+        # SSH/GPG agent configuration
+        (lib.mkOrder 700 ''
+          # handle SSH differences between Prompt on iOS and a machine with Yubikey PGP available
+          # if we're connected via a traditional SSH agent it's probably Prompt
+          GPG_AGENT_SSH_SOCK=$(gpgconf --list-dirs agent-ssh-socket)
+          if [[ -n "$SSH_AUTH_SOCK" && "$SSH_AUTH_SOCK" != "$GPG_AGENT_SSH_SOCK" && $(readlink -f $SSH_AUTH_SOCK) != $GPG_AGENT_SSH_SOCK ]]; then
+            # use ssh signing with the provided key
+            export GIT_CONFIG_COUNT=3
+            export GIT_CONFIG_KEY_0=gpg.format
+            export GIT_CONFIG_VALUE_0=ssh
+            export GIT_CONFIG_KEY_1=user.signingkey
+            export GIT_CONFIG_VALUE_1=~/.ssh/id_charanda_enclave.pub
+            export GIT_CONFIG_KEY_2=gpg.ssh.allowedSignersFile
+            export GIT_CONFIG_VALUE_2=~/.config/git/allowed-signers
           else
-            smug start $session
+            if [[ -z "$SSH_AUTH_SOCK" ]]; then
+              export SSH_AUTH_SOCK="$GPG_AGENT_SSH_SOCK"
+            fi
           fi
-        }
+        '')
 
-        function fullscreen() {
-          smug-session fullscreen
-        } 
+        # Shell functions
+        (lib.mkOrder 800 ''
+          function tmux-has-session() {
+            session=$1
+            tmux has-session -t $session 2>/dev/null
+          }
 
-        function window() {
-          smug-session window
-        } 
-      '';
-      
-      initExtraBeforeCompInit = ''
-        fpath+=($HOME/workspace/oh-my-zsh-custom/completions)
-      '';
+          function smug-session() {
+            session=$1
+
+            if [[ ! -d "$XDG_RUNTIME_DIR/ssh" ]]; then
+              mkdir -p "$XDG_RUNTIME_DIR/ssh"
+            fi
+            if [[ "SSH_AUTH_SOCK" != "$XDG_RUNTIME_DIR/ssh/s.ssh-agent.smug-$session" ]]; then
+              ln -sf $(readlink -f $SSH_AUTH_SOCK) "$XDG_RUNTIME_DIR/ssh/s.ssh-agent.smug-$session"
+              export SSH_AUTH_SOCK="$XDG_RUNTIME_DIR/ssh/s.ssh-agent.smug-$session"
+            fi
+            if [[ -f $(pwd)/.smug.yml ]]; then
+              smug start
+            else
+              smug start $session
+            fi
+          }
+
+          function fullscreen() {
+            smug-session fullscreen
+          }
+
+          function window() {
+            smug-session window
+          }
+        '')
+      ];
       
       envExtra = ''
         export XDG_CONFIG_HOME="${config.xdg.configHome}"

--- a/home/modules/security/gpg-agent.nix
+++ b/home/modules/security/gpg-agent.nix
@@ -17,7 +17,7 @@ in {
 
   programs = {
     zsh = {
-      initExtra = ''
+      initContent = ''
         if [[ -z $SSH_TTY ]]; then
           plugins+=( gpg-agent )
         fi

--- a/overlays/default.nix
+++ b/overlays/default.nix
@@ -32,7 +32,7 @@
   # be accessible through 'pkgs.unstable'
   unstable-packages = final: _prev: {
     unstable = import inputs.nixpkgs-unstable {
-      system = final.system;
+      system = final.stdenv.hostPlatform.system;
       config.allowUnfree = true;
     };
   };
@@ -40,7 +40,7 @@
   nur-packages = final: prev: {
     nur = import inputs.nur {
       pkgs = final;
-      system = final.system;
+      system = final.stdenv.hostPlatform.system;
     };
   };
 }


### PR DESCRIPTION
TL;DR
-----

Silences three deprecation warnings during `make user` by updating overlay system references and migrating zsh init options to their replacements.

Details
-------

Replaces `final.system` with `final.stdenv.hostPlatform.system` in the unstable-packages and nur-packages overlays. The `system` attribute on package sets is deprecated in favor of the more explicit host platform path.

Migrates zsh configuration from `initExtra` and `initExtraBeforeCompInit` to the unified `initContent` option. Organizes initialization by purpose with explicit `lib.mkOrder` values:

- **550**: Completion paths (fpath additions before compinit)
- **600**: Shell options (setopts for vi mode, history, autocorrect)
- **700**: SSH/GPG agent configuration (Prompt on iOS vs Yubikey detection)
- **800**: Shell functions (tmux/smug helpers)

Affects `overlays/default.nix`, `home/modules/base/default.nix`, and `home/modules/security/gpg-agent.nix`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)