### PR TITLE
Improves standalone flake support

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -131,21 +131,19 @@
           generateConfigs = userConfigs: profiles:
             builtins.listToAttrs (
               builtins.concatLists (
-                builtins.concatLists (
-                  builtins.map (system:
-                    builtins.concatLists (
-                      builtins.map (username:
-                        let userConfig = userConfigs.${username}; in
-                        builtins.map (profile: {
-                          name =
-                            let base = if profile == "full" then username else "${username}:${profile}";
-                            in "${base}@${system}";
-                          value = mkHomeConfig ({ inherit system username profile; } // userConfig);
-                        }) profiles
-                      ) (builtins.attrNames userConfigs)
-                    )
-                  ) supportedSystems
-                )
+                builtins.map (system:
+                  builtins.concatLists (
+                    builtins.map (username:
+                      let userConfig = userConfigs.${username}; in
+                      builtins.map (profile: {
+                        name =
+                          let base = if profile == "full" then username else "${username}:${profile}";
+                          in "${base}@${system}";
+                        value = mkHomeConfig ({ inherit system username profile; } // userConfig);
+                      }) profiles
+                    ) (builtins.attrNames userConfigs)
+                  )
+                ) supportedSystems
               )
             );
         in

--- a/flake.nix
+++ b/flake.nix
@@ -137,7 +137,7 @@
                       let userConfig = userConfigs.${username}; in
                       builtins.map (profile: {
                         name =
-                          let base = if profile == "full" then username else "${username}-${profile}";
+                          let base = if profile == "full" then username else "${username}:${profile}";
                           in "${base}@${system}";
                         value = mkHomeConfig ({ inherit system username profile; } // userConfig);
                       }) profiles

--- a/flake.nix
+++ b/flake.nix
@@ -137,7 +137,7 @@
                       let userConfig = userConfigs.${username}; in
                       builtins.map (profile: {
                         name =
-                          let base = if profile == "full" then username else "${username}:${profile}";
+                          let base = if profile == "full" then username else "${username}.${profile}";
                           in "${base}@${system}";
                         value = mkHomeConfig ({ inherit system username profile; } // userConfig);
                       }) profiles

--- a/flake.nix
+++ b/flake.nix
@@ -22,13 +22,13 @@
 
   };
 
-  outputs = { self, nixpkgs, home-manager, darwin, ...}@inputs: 
+  outputs = { self, nixpkgs, home-manager, darwin, ...}@inputs:
     let
       inherit (self) outputs;
-      system = builtins.currentSystem;
-      isDarwin = nixpkgs.legacyPackages.${system}.stdenv.isDarwin;
-      
-      pkgs = import nixpkgs {
+
+      supportedSystems = [ "aarch64-darwin" "x86_64-linux" ];
+
+      mkPkgs = system: import nixpkgs {
         inherit system;
         overlays = [
           inputs.nur.overlays.default
@@ -36,12 +36,12 @@
       };
 
       # Helper function to create home configurations with profiles
-      mkHomeConfig = { username, gitEmail, profile ? "full"
-        , homeDirectory ? (if isDarwin then "/Users/${username}" else "/home/${username}")
+      mkHomeConfig = { system, username, gitEmail, profile ? "full"
+        , homeDirectory ? (if (mkPkgs system).stdenv.isDarwin then "/Users/${username}" else "/home/${username}")
         , homeModule ? (./. + "/home/users/${username}/home.nix")
       }:
         home-manager.lib.homeManagerConfiguration {
-          inherit pkgs;
+          pkgs = mkPkgs system;
           extraSpecialArgs = {inherit inputs outputs username homeDirectory gitEmail profile;};
           modules = [
             homeModule
@@ -104,7 +104,7 @@
         };
       }; 
 
-      homeConfigurations = 
+      homeConfigurations =
         let
           # User configurations with different profiles
           userConfigs = {
@@ -122,21 +122,30 @@
               gitEmail = "";
             };
           };
-          
+
           # Available profiles
           profiles = [ "full" "development" "minimal" "server" ];
-          
-          # Generate configurations for each user-profile combination
+
+          # Generate configurations for each user-profile-system combination
+          # Names: "user@system", "user:profile@system"
           generateConfigs = userConfigs: profiles:
             builtins.listToAttrs (
               builtins.concatLists (
-                builtins.map (username:
-                  let userConfig = userConfigs.${username}; in
-                  builtins.map (profile: {
-                    name = if profile == "full" then username else "${username}:${profile}";
-                    value = mkHomeConfig ({ inherit username profile; } // userConfig);
-                  }) profiles
-                ) (builtins.attrNames userConfigs)
+                builtins.concatLists (
+                  builtins.map (system:
+                    builtins.concatLists (
+                      builtins.map (username:
+                        let userConfig = userConfigs.${username}; in
+                        builtins.map (profile: {
+                          name =
+                            let base = if profile == "full" then username else "${username}:${profile}";
+                            in "${base}@${system}";
+                          value = mkHomeConfig ({ inherit system username profile; } // userConfig);
+                        }) profiles
+                      ) (builtins.attrNames userConfigs)
+                    )
+                  ) supportedSystems
+                )
               )
             );
         in

--- a/flake.nix
+++ b/flake.nix
@@ -137,7 +137,7 @@
                       let userConfig = userConfigs.${username}; in
                       builtins.map (profile: {
                         name =
-                          let base = if profile == "full" then username else "${username}.${profile}";
+                          let base = if profile == "full" then username else "${username}-${profile}";
                           in "${base}@${system}";
                         value = mkHomeConfig ({ inherit system username profile; } // userConfig);
                       }) profiles

--- a/home/modules/base/default.nix
+++ b/home/modules/base/default.nix
@@ -76,7 +76,7 @@ in {
         mkdir -p ~/sandbox
       '';
 
-      customizeOmz = lib.hm.dag.entryAfter [ "writeBoundary" "installPackages" ] ''
+      customizeOmz = lib.hm.dag.entryAfter [ "linkGeneration" ] ''
         if [ ! -d ~/workspace/oh-my-zsh-custom ]; then
           ${pkgs.git}/bin/git clone https://github.com/crdant/oh-my-zsh-custom ~/workspace/oh-my-zsh-custom || {
             echo "Warning: Failed to clone oh-my-zsh-custom repository. Skipping..."

--- a/home/modules/base/default.nix
+++ b/home/modules/base/default.nix
@@ -76,7 +76,7 @@ in {
         mkdir -p ~/sandbox
       '';
 
-      customizeOmz = lib.hm.dag.entryAfter [ "writeBoundary" "installPackages" "git" ] ''
+      customizeOmz = lib.hm.dag.entryAfter [ "writeBoundary" "installPackages" ] ''
         if [ ! -d ~/workspace/oh-my-zsh-custom ]; then
           ${pkgs.git}/bin/git clone https://github.com/crdant/oh-my-zsh-custom ~/workspace/oh-my-zsh-custom || {
             echo "Warning: Failed to clone oh-my-zsh-custom repository. Skipping..."

--- a/home/modules/base/default.nix
+++ b/home/modules/base/default.nix
@@ -1,4 +1,4 @@
-{ inputs, outputs, config, pkgs, lib, username, homeDirectory, secretsFile ? null, ... }:
+{ inputs, outputs, config, pkgs, lib, username, homeDirectory, ... }:
 
 let 
   isDarwin = pkgs.stdenv.isDarwin;
@@ -366,13 +366,6 @@ in {
     };
   };
   
-  sops = lib.mkIf (secretsFile != null) {
-    defaultSopsFile = secretsFile;
-    gnupg = {
-      home = "${config.home.homeDirectory}/.gnupg";
-    };
-  };
-
   xdg = {
     enable = true;
     configFile = {

--- a/home/modules/secrets/default.nix
+++ b/home/modules/secrets/default.nix
@@ -1,0 +1,22 @@
+{ inputs, config, pkgs, lib, secretsFile ? null, ... }:
+
+let
+  isLinux = pkgs.stdenv.isLinux;
+in {
+  imports = [
+    inputs.sops-nix.homeManagerModules.sops
+  ];
+
+  sops = lib.mkIf (secretsFile != null) {
+    defaultSopsFile = secretsFile;
+    gnupg = {
+      home = "${config.home.homeDirectory}/.gnupg";
+    };
+  };
+
+  # Force sops-nix activation to run after systemd reloads its units,
+  # otherwise the first switch fails with "Unit sops-nix.service not found"
+  home.activation.reloadSystemdBeforeSops = lib.mkIf (isLinux && secretsFile != null) (
+    lib.hm.dag.entryBetween [ "sops-nix" ] [ "reloadSystemd" ] ""
+  );
+}

--- a/home/modules/security/default.nix
+++ b/home/modules/security/default.nix
@@ -6,7 +6,6 @@ let
 in {
   imports = [
     inputs._1password-shell-plugins.hmModules.default
-    inputs.sops-nix.homeManagerModules.sops
   ];
   
   # Security-related packages
@@ -92,20 +91,6 @@ in {
       '';
     };
   };
-  
-  sops = lib.mkIf (secretsFile != null) {
-    defaultSopsFile = secretsFile;
-    gnupg = {
-      home = "${config.home.homeDirectory}/.gnupg";
-    };
-  };
-
-  # Force sops-nix activation to run after systemd reloads its units,
-  # otherwise the first switch fails with "Unit sops-nix.service not found"
-  home.activation.reloadSystemdBeforeSops = lib.mkIf (isLinux && secretsFile != null) (
-    lib.hm.dag.entryBetween [ "sops-nix" ] [ "reloadSystemd" ] ""
-  );
-  
   
   programs = {
     zsh = {

--- a/home/modules/security/default.nix
+++ b/home/modules/security/default.nix
@@ -99,6 +99,12 @@ in {
       home = "${config.home.homeDirectory}/.gnupg";
     };
   };
+
+  # Force sops-nix activation to run after systemd reloads its units,
+  # otherwise the first switch fails with "Unit sops-nix.service not found"
+  home.activation.reloadSystemdBeforeSops = lib.mkIf (isLinux && secretsFile != null) (
+    lib.hm.dag.entryBetween [ "sops-nix" ] [ "reloadSystemd" ] ""
+  );
   
   
   programs = {

--- a/home/profiles/development.nix
+++ b/home/profiles/development.nix
@@ -18,6 +18,7 @@
     ../modules/infrastructure
     ../modules/kubernetes
     ../modules/ai
+    ../modules/secrets
     ../modules/security
     ../modules/certificates
   ] ;

--- a/home/profiles/full.nix
+++ b/home/profiles/full.nix
@@ -16,6 +16,7 @@
     ../modules/cicd
     ../modules/kubernetes
     ../modules/replicated
+    ../modules/secrets
     ../modules/security
     ../modules/certificates
     ../modules/aws

--- a/home/profiles/minimal.nix
+++ b/home/profiles/minimal.nix
@@ -1,5 +1,5 @@
 { pkgs, ... }: {
   imports = [
     ../modules/base
-  ] 
+  ];
 }

--- a/home/profiles/server.nix
+++ b/home/profiles/server.nix
@@ -2,6 +2,7 @@
   # AI-focused profile for a home environment on a remote server
   imports = [
     ../modules/base
+    ../modules/secrets
     ../modules/security
     ../modules/editor
     ../modules/homelab


### PR DESCRIPTION
TL;DR
-----

Removes `builtins.currentSystem` so `homeConfigurations` can be consumed from remote flake references without `--impure`.

Details
-------

Replaces the top-level `system`, `isDarwin`, and `pkgs` bindings with an explicit `supportedSystems` list and a `mkPkgs` function that instantiates nixpkgs per system. The previous approach used `builtins.currentSystem`, which Nix flakes prohibit in pure evaluation — preventing remote consumption like `nix run home-manager -- switch --flake github:crdant/dotfiles#crdant@x86_64-linux`.

Adds `system` as a required parameter to `mkHomeConfig` and derives `homeDirectory` and `pkgs` from it. Generates homeConfiguration attribute names qualified by system (`user@aarch64-darwin`, `user:profile@x86_64-linux`) so each configuration is unambiguous and evaluable without impure builtins.

Supports `aarch64-darwin` and `x86_64-linux`. No changes to `darwinConfigurations` or `nixosConfigurations`, which already specify their system explicitly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)