### PR TITLE
Corrects SnowSQL config for key-pair auth

### DIFF
--- a/home/modules/data/config/snowsql/config
+++ b/home/modules/data/config/snowsql/config
@@ -1,24 +1,16 @@
-[connections]          
-# *WARNING* *WARNING* *WARNING* *WARNING* *WARNING* *WARNING*
-# 
-# The Snowflake user password is stored in plain text in this file.
-# Pay special attention to the management of this file.
-# Thank you.
-# 
-# *WARNING* *WARNING* *WARNING* *WARNING* *WARNING* *WARNING*
-
-#If a connection doesn't specify a value, it will default to these
+[connections]
+# If a connection doesn't specify a value, it will default to these
 #
 account = "UFGKXST-DCA66381"
 user = "CHUCK@REPLICATED.COM"
-authenticator = "externalbrowser"
+authenticator = "snowflake_jwt"
 role = "TRANSFORMER_DEV"
 private_key_path = "/Users/chuck/.ssh/id_snowflake.p8"
 
 # [connections.raw]
 # account = "UFGKXST-DCA66381"
 # user = "CHUCK@REPLICATED.COM"
-# authenticator = "snowflake"
+# authenticator = "snowflake_jwt"
 # role = "TRANSFORMER_DEV"
 # database = "RAW"
 # private_key_path = "/Users/chuck/.ssh/id_snowflake.p8"
@@ -26,7 +18,7 @@ private_key_path = "/Users/chuck/.ssh/id_snowflake.p8"
 # [connections.dev]
 # account = "UFGKXST-DCA66381"
 # user = "CHUCK@REPLICATED.COM"
-# authenticator = "snowflake"
+# authenticator = "snowflake_jwt"
 # role = "TRANSFORMER_DEV"
 # database = "ANALYTICS_DEV"
 # private_key_path = "/Users/chuck/.ssh/id_snowflake.p8"
@@ -34,7 +26,7 @@ private_key_path = "/Users/chuck/.ssh/id_snowflake.p8"
 # [connections.prod]
 # account = "UFGKXST-DCA66381"
 # user = "CHUCK@REPLICATED.COM"
-# authenticator = "snowflake"
+# authenticator = "snowflake_jwt"
 # role = "TRANSFORMER_DEV"
 # database = "ANALYTICS_DEV"
 # schema = "ANALYTICS"

--- a/home/modules/data/default.nix
+++ b/home/modules/data/default.nix
@@ -1,6 +1,6 @@
 { inputs, outputs, config, pkgs, lib, ... }:
 
-let 
+let
   isDarwin = pkgs.stdenv.isDarwin;
   isLinux = pkgs.stdenv.isLinux;
 in {
@@ -10,6 +10,11 @@ in {
   ] ++ lib.optionals isLinux [
     snowsql
   ];
+
+  sops.secrets."snowflake/private_key" = {
+    path = "${config.home.homeDirectory}/.ssh/id_snowflake.p8";
+    mode = "0600";
+  };
 
   home.file = {
     ".snowsql" = {

--- a/home/users/crdant/secrets.yaml
+++ b/home/users/crdant/secrets.yaml
@@ -1,39 +1,41 @@
 github:
-    token: ENC[AES256_GCM,data:f3KQ519Ctj3qSAPqfepszlopLlZ3+ZSmWd4+Jz0YVzwUb2Hyoe+miA==,iv:AGkJ++9bCLOWd64Yx4WViBrR+MMV4ntY2tkg2lj2lhU=,tag:UqWW0u+ZpoDbNEsnEBiT7A==,type:str]
+    token: ENC[AES256_GCM,data:zXe5EoHZlDIF/dFMSH9Wh5e0IFJdxySlQK/KOihBANpwhtOdIdBggQ==,iv:VTGfsPczV0hQlJRSKbYOWAEw9qh127vQhiHzmkRF6bk=,tag:h75NibhH9K4e1oOZczX9Xw==,type:str]
 anthropic:
     apiKeys:
-        chuck@replicated.com: ENC[AES256_GCM,data:xQbsr0KAI+0He3/Hx6GntNmPouz8ag3GQbYZ3geLFQP87NisQ7w5qtrU3B4QHb2yOySfQhV4UlG0GdA6gdOptHvgGUKkbSjVB1YuodUpqgWAvTvDsmeJ6XMWxyUzsgFUJ72nG/TeFPAOugQ=,iv:M701GTFcWqY6NKypkVUE4xYn2okAyXqHeJM3L2a1DM0=,tag:B3XmTrSun8ovgNUWZnG1IA==,type:str]
-        chuck@crdant.io: ENC[AES256_GCM,data:qOsQY01wBEpnrgprx5qBIjpvfZNeCCMoyxF/jpNTD9Vxtdx4GpfhpUX3eJB0ESsidXIK2vwDLINWvW+UEmlAkRYfpv3wSPW1EcIclz3WW+VznvMeGPIvrkj3LKMRX/3oPQ4Qami/ZyvtttM3,iv:eImT7OIxcBO8TbQfdD9rpJ6MmQI0GZPVipDi3XPwrrk=,tag:VYwTUvp+5+NL9dRyrjL2bg==,type:str]
+        chuck@replicated.com: ENC[AES256_GCM,data:oIdHA4SQE066XfR/mmUTRMBv2XEKrZGIlnOJ+tDneF3N9xXSINBso+nFooGYRHfBDjlpcwJBr4IEndoqVxxwnEhTy/zZFZndIXPQIDbygaZc0ON51vLlCYtQ8iBGHpYEMWCRCszwLrS7XTs=,iv:0LgxTfqAo3iG06gV0We/EjNl8UcjbFyLp2PzI8whOTM=,tag:LAFGU69+7y78bWDmRDjexA==,type:str]
+        chuck@crdant.io: ENC[AES256_GCM,data:khoB9wl4Ipnlh8BB66tQRJvttYZnISF9gzef6KDsYrbWmYFuDTFe91wnTsBg8gZdr+dzkO7IWRNRo9Ze81DRYoI9Xvr6DMgnPAcsuTgcTAdcV9y7RhhGWcroA7FCg9RWYgvIDmfResMIo/+J,iv:cATTImONjSFDZBpsnuFBfHx5r+bTf9aNEo79EGTIMGk=,tag:nixyU4pY1H7i8H54zmK+Pg==,type:str]
 google:
     maps:
-        apiKey: ENC[AES256_GCM,data:TNE+a5KobudXuMp3dOrFIPTESgj1MTzYLQ4Z5BLquwiOSwLq5fcm,iv:kyRnJ1My7ADLBsajzDAay+Dydcjr9ZT8WQvXVx0XMC4=,tag:5jOqTiNLxjGa+sjlcbBtmw==,type:str]
+        apiKey: ENC[AES256_GCM,data:ueq8ehqDJ2tqK5wWD3DQgqOEhsnN3OhxcX+q7Vl/DNciH2h10nz6,iv:zIP6Av32+JIngRt1JBM5eSb5WDBCPqoW5DDjGhoRTHA=,tag:zttTJJAZcGP7JtzvztWiOw==,type:str]
 slack:
     shortrib:
         slackernews:
-            userToken: ENC[AES256_GCM,data:VjgOUGLolvbTgt7SUh1VHdIfWYaT12D6MjX8Jo+BP/BTSZFnJzSxR/scDgBWb05Lic74iWwmCYAxbzewvGliFC8OHLuwQQZ34wjd2bfIng==,iv:Nl/wSoTIgeIQVnKeofjf1ZNUXacCJBRrgo3NuVNFVJI=,tag:XShTQ4WN1bkc/pqi72JxVQ==,type:str]
-            botToken: ENC[AES256_GCM,data:XoK/4emyLpwXOj8uc5cL8cgX2i/0lK3sYhGDkNv6ui2rKcXhnp/cKAbjcGz0c5PgbMxr0WOVF90e,iv:mzF4fN1mq7iGPtNwDUfrdmplDeGkdeRwKDzyKOhz3mg=,tag:jn1eon8+v94i+6idGdhFNQ==,type:str]
+            userToken: ENC[AES256_GCM,data:EmqsGTkozer1HfScB9x6eQ4DSdv5/lX5WB05oiDJ3ngeVGwp+u1yGtnT/b4TGin2GD2DGBCH9hv1fjEpjyr9xKfgKQzvnNo2/LK99xiN7w==,iv:33RQdUdJhmniSvJ2IZJspxhB3SAwjXiR+NAdouFfzqE=,tag:ssZ0YBdOy0WONT4ypv8iGA==,type:str]
+            botToken: ENC[AES256_GCM,data:2ZXf/vjIdPNv3pmr7ojhrc22qGpGguVkJLEvZHwy012IKD5+D2T7tl1DZynYFGtqwH6298AtCJLc,iv:z/PkTS4hwEY6CqXBp39COzVcQg31wMFRq2zmo1k7O5I=,tag:jIVSL1VaGMOvgHGLfK0EQA==,type:str]
 mbta:
-    apiKey: ENC[AES256_GCM,data:kZbmOtf21WAJltCep65JZrmJ0gEjlKNuoHY3EnX370Q=,iv:fyV1IW3jhCJC7FHflFDrrqe4ohvrp7Z4sxNH+oCin4g=,tag:MwxWBnxhyMAR7LSrvy645w==,type:str]
+    apiKey: ENC[AES256_GCM,data:vxfVF8gucrPK9d9AXqcCxoy8d3EKgc1bBjcL0xGC5qM=,iv:IO/8h9p8dbW1eLObWmy5642cic8APoMUUOy7PJa9nfM=,tag:2hi5oNsllJN24ITAoPEafQ==,type:str]
 omni:
-    api_token: ENC[AES256_GCM,data:h+AOxV+vpVFs3eD9w5FNSJPP0YygPBkaqV53UYTEOMfW16125Vg/7TFZyhCDN5Ox8nFyFFR2EsfyYabNu+xyXwI=,iv:MsHSJB3KF9Zc9nyvCiJdkrr03u5IDbsMtm0D190a450=,tag:9CXXoZFTBeBZZ3fyNJKasw==,type:str]
+    api_token: ENC[AES256_GCM,data:8fpLMDcFz/8Vcy27Jcfv1nHKMcVJ3dTQ+suZMGlSvOnZSmBpfM3qtoZQZfttf71X5c9NP+1nd3q9tUfbplpaxbU=,iv:L3zxdBEkkGy43CBkb6lwbHK4GNkCtkrOOTFzsRqqnzY=,tag:0u6NM/1cRNMrEnlDcMZUng==,type:str]
 firecrawl:
-    api_key: ENC[AES256_GCM,data:e6BcquQEeFEL4auSDlZ7NIEvjZ/y/LszpVdWRyRsgsrQkWQ=,iv:w2zaa9NgDVyqbNJozT1b9oV1a+4T6DKAqhCKuuc73Cc=,tag:KD+qauOEdc7ZY7MvbVLdUQ==,type:str]
+    api_key: ENC[AES256_GCM,data:FF3QERAODdAfGv3eWRRNC7TFxdtr3kDIUFNACvC0X4NiIxo=,iv:mx068adyqaDbrVWPpFHCUwEdrrY99Z4vlcD7UZU5K5w=,tag:opCkDSb+147K43So39bPHA==,type:str]
 shortcut:
-    api_token: ENC[AES256_GCM,data:jZXgCZDM4FWl3pWImUig4RJ1/f0sjDdaOae+mbjsPNe+CcRjQ4U5sNcRT0EVLxMrIXCYOz8OGviu1IMiCBh6aB06XEJkXPk60K3v0A4csz3ikVfsDt7A7aZG06zRRpUvlZBIOdkDTnv0CjuMN59Ehexxw883IwUE6CnOFJaLIcMaxNHyxf3TA9DoE1f4aWEpZK0gkcg9e6+5wV7yhhiimQ==,iv:u3K9Rf0X0Qjpj1QyHx94UpZiQvV9DOWesdnnFpKSNXk=,tag:1MKzqysNBr/Zm30SemtCeg==,type:str]
+    api_token: ENC[AES256_GCM,data:awEzomUYIbvOBs7h6J6TUPRq9Hrdqr3iix5h7pvKoCVH5E0lZJDxNVoMTfxLlFSlhS0r7eTy9Ac7e0kXrOhT6xVk+3POA/dSlsPoa6LfPm/c+9B449Q0uH+Hlro5O7w748qei86DPp+jCZbsWNfamQd88Chcxip+eJvIMjg63Tz4cHZBomIeE4dzMZjWBKgwDk8aAUz86Oh9REQBgAeMsA==,iv:XqnptxQHoeulB5SDHnLL3j1x0vI9cBlcogKu6kYq3zM=,tag:305w4JUBVt8ojCp6JcfdAQ==,type:str]
+snowflake:
+    private_key: ENC[AES256_GCM,data:+7w9Tzvo6a+VE1M6iTcWeDAR3WzTAJUCbmQd+72k4rx0xrDSwTARC7MoQL32yloFrCsan54T15+fwSvZXHcKKk0MTCczDJfabvdAZzzsDhCKBwULzeNi3/udo3bJ4IJPQex54vR0mpEsdEBKB0VI+79b4YUapYCfmammAG5WuGK968GcsSMRzydWRie3ws4xiazIa9v3BmAwUrrzpUudpuvmE5xXKqyV1Dq1mZcoBPSHTcoHCKW/vD11zqo2dOD0FLKu1Rttr6zWHQz4q6EyrtfT2eBZftNnH3RNBHcCB1DencdvcjR7M1cU/vAkm9VKMEBVxqK5WWzOS+bXVjM9RfCeFrUTwMHKPsTrZsjVnui0Y7vOow8Q0INQJ/4pUjXhcSXc/nsh/KqNpY20XshgD/P2Li+KAI+zZyg9h0ZyKLZFmewWZO3KMDvezZsyYXqrxMR41AEPdmwdpNpzTLVPXfyE3xf5CHGSkKMLwzacMFddRCB8Dwc5ndoGPSVJHNMNIIHstyybxfMo/fP6/DhjF/+Tjp+4bFwTSHximLU6CtCSeRG7vYS7FTCTt08kcAoDeD52uayZ9L3CaE8EljVTGZAAzW9EmGKslOZvtXZFcJPIK6kCyOwULca7Mq8mDLYUiQhUbeob9ubd8FPpWkC9w6Bph0DQpsQvRqzyxtIEn2T/NGaLyet+a1jHUKSxJhKDZnA7EyliTsfk+3gSR8itfbmVO/5R2mMGmvVxb4dCS2lvvtMxa1kYUQW7Uck4pyPrAaRAn0OnIRwGyrhVQsiyf3bNEP50Qo7kslwppqpFWoWkz40V6mv93MffI+TroJdAq5H1HaY0dlcvYkPVnwUfS5OFNvRT0K7HwKlyIgnc2/3+wHA1E+43eMInz3rOyC0CaGWqVf/8igV1xbMX3idFkf7b1C7x/+AtXtN9KswaykNI8o8WMaHAI6fF7aPneT+2EAtWwXf8lgzXhD5t30SvW3X25aLRbxg1WPLIMKQ6HBteUqdVGm2isKtayTbFxFgd3lFm0w5q3bnBwrYoKb7/vaOdmp17kdVJnOZ7Cw447MYmkLB8C4h/Al1WQpe5DifxLtiGpBcFOSKcRgWcXC+e7EsxH7lQqjvhHfhjP3pI4aY648oprzXevOVqOHkTmixjAUngwEmMu/Z3Px45nDRUf7Z6OQRi0+TuA6TecWL8jEQlytzPF7yrm6UrvCfjDb4h8oC3Y3S+kULAgJxGGKmVLv8cQZbIl2XQQXyv2uBh6hMbYxSyZqg/S6p66k+kmk9arOo12JfvH29PuJ6rU585Zdv5BPosiNaMZCHkmehqnuNyZjd0957UMVQM8zTJALj1wBM++sdrp39poLFcQv3rBZ9YafwUUN1Y8x210nj7pkbv3WRRWV4XRCR/YHfMSpTCt+optMNn4ZOQCR/3EDkthPRFQ77zM0XwRtbUQ3lHTAJmf5fbPnAW2J2GdcAb7kp6ONUwifqWppX1AscrAPTd5uX1cdTDl8wm6WPTcp4Vs40OpMAmjiZZ+QsljbEKnhLWDbn/ougQCSToXRdfreje/ONh70VvuVLdQRrEtAHaJT6Fq7qkDm/Tn7xo/gMIEd4Aa4RJ9uv8aqsckRACPoKHo9z5vBKkE32ycl/0MQIG4fyUCFq3YOV0tbmV82r9sxhLnhrf3+XTwH+ZaRcgzfaWb4oBlSNVqLnXP2vqQw1kYDMdt2VFUXrze9CnW0JNcrl8vl5PBnLzU0D1rW8OQ1xj0D3MRpjMHlCvxWBpMlKsJimCG0SqCFnW9hfYxIj/7LMPYVDTx6MfeQBzPS5W3fdZa8I4Ldil9HFItXScigGxFMD6bwFnAp3KISoCk3LINTkKRUBLKNHXyZCYoOjTtCkot8VyLu2oWpg8jZDIE1avHXsoPPCkknaowbWRVcr/zZDV22JGPkekxe9FtJtje9W4cmxZtF5f0xI/6TByiZ/q3jTEqW97xUqZQNqCYuDmNUtOZUUEon2VHs/sdSzK19TuxtF4lNzv2wBi9HTe2HPjXs8VhRRCVoBHqBsxxsU10pmzRsEMOelp8Iz/Ta+mmqQdGpz5zhsCO+CqD5SPDH7PHAiWdtNXDHwvq5jfzRcPO+z6fH33IULM+csIOrl26fjwAos+2OZiDYJhHLbKu10iNTSD0WCMrIe6bXOVXVJZOGHHw/oJ4oVG2P7oI8mVz6k3kXX7t97pqTZghRUwZ1KpTTg9E8ip419arU9h9Qr1HNis4G5595vgvvdvDzJf7IUEG4J76s6zMPRXRbr6pK1S8mHDmU+pTLJORQPFfyC59dK4wUWFreWL6XAqsj8sndAV+JSMf5pkgYOtyqR3ouzJDsfZTatYmZq7MnsnS3kKpco/CJJ9s5IyEVgqlQBD82XqmUWuQ00Z81PN6LMwEpO4GuUdNem5AzbUbxQFD7RK34EpZn5hwDpogL1I52EFxJA8esdksV82LxT3lMEIcLoeB+ENWUjIjNbS05YmxBeImzLLxNaYAl7zciYgtJ4xrf+CcOStHNQ=,iv:/ntk9qbtif6oerxnbsjxCw7/Fkh3mBIHrAzuTJr+Gdg=,tag:0+FgFC4/ZEeHr8XE/jWyiw==,type:str]
 sops:
-    lastmodified: "2026-02-18T16:24:19Z"
-    mac: ENC[AES256_GCM,data:PY7vp4SToND17pHS+/4FNdmbNTna5gUEdokzYFVnu4uf1e1LcVfNWSNB+ZhzA2ln+4tdbYQaP6njPnRi6qLdO/9sJ3pbpf7dXvJBUktzj6PXH1+z+G0JEkCJhmE3uK+w57b7gc2ciXNYKumFPPMHGGeJNcsw1rY8kVwLzifD3qg=,iv:NW8iJ03HseCZCDrcasx8ZaRFls/oCGwYYtUThVvGyPo=,tag:2yqUlVY+cF86rEO6ckOLkQ==,type:str]
+    lastmodified: "2026-04-17T15:18:44Z"
+    mac: ENC[AES256_GCM,data:4Vc39pTTqr3w8sjHrgCyaONBZr/+oL3ek0w2VHcr92GDt7HjR6kjOO5mdBDN5Ta5d1jJSdUgw5+daJdInY803VbWP9ODHgUYRH+5SOttxz0TaOwHnaIhy/nFubr7hYuE6EHp8tP3X66pPRYVsv5Qyj1ATTY/jEeTrDLNL5UZwCg=,iv:g4T3/zCGQCvgO4vwFrxOSER78jUFSB0WSPJzpPPv7YA=,tag:Of8Mb2E6+QLrWMVs91ICYQ==,type:str]
     pgp:
-        - created_at: "2026-02-18T16:24:19Z"
+        - created_at: "2026-04-17T15:18:44Z"
           enc: |-
             -----BEGIN PGP MESSAGE-----
 
-            hF4DYhYgzaKQYR0SAQdAC7hUnLfehXf9q5C4U1kK2pCzVUgRkNAh9Y4mmevvgEUw
-            TxizHpS/famq1cJGD6FcP8ETBg6vFuekREA/Ny2ZZomwLLcj7Cj6z/sj7zoNLy/B
-            0lwBeGUygSinHk+GDgFHh8JWeFzGkQzys/s/FqKDvU9GmDeZsOghenqeNpGLjpG2
-            dxd1/X9oE0ScNawLsDC0e3qyEYgA4dwT4+FeCRJwHHz53utpP81xCup+xZfifA==
-            =6g48
+            hF4DYhYgzaKQYR0SAQdAYYk3Y5Htvnlb7Z2f745D6Czy7qrw/Gt1PJB1pcA7wX4w
+            9RPddqiStkXBOy3hn4KAFqKKMtGekhK0NZffH54t64Gc7blsk3K0Enk1Q7PHKpN/
+            0l4By6mrWLPUI2w6Ar7gYAr0YFmUh1BNtGBvSHob9bUTT8wW+EHB+us0u9RCV0gg
+            I5fpbLPx2Gm/AeB9mmu06P2WHzY8ydh2ABkrxvQT0aA4tqe0/+ghD4lH6ruQJMSI
+            =7/fo
             -----END PGP MESSAGE-----
           fp: 905EBD494A6AA2B774ED5C67621620CDA290611D
     unencrypted_suffix: _unencrypted
-    version: 3.11.0
+    version: 3.12.1


### PR DESCRIPTION
TL;DR
-----

Switches SnowSQL authentication from external browser to key-pair (JWT) and provisions the private key from SOPS secrets.

Details
-------

Replaces `authenticator = "externalbrowser"` with `snowflake_jwt` on the default connection, which is the correct authenticator for private key authentication. Updates the commented-out connection profiles (raw, dev, prod) to match so they work correctly if uncommented.

Adds a `sops.secrets` declaration in the data module to decrypt and write the Snowflake private key to `~/.ssh/id_snowflake.p8` with mode `0600`. The key was previously referenced in the config but never provisioned—it now lives in the encrypted secrets file alongside other credentials.

Removes the stock password warning boilerplate since key-pair auth doesn't involve passwords.

🤖 Generated with [Claude Code](https://claude.com/claude-code)