### PR TITLE
Fixes SSH agent detection for launchd

### DIFF
--- a/home/modules/base/default.nix
+++ b/home/modules/base/default.nix
@@ -236,7 +236,12 @@ in {
           # handle SSH differences between Prompt on iOS and a machine with Yubikey PGP available
           # if we're connected via a traditional SSH agent it's probably Prompt
           GPG_AGENT_SSH_SOCK=$(gpgconf --list-dirs agent-ssh-socket)
-          if [[ -n "$SSH_AUTH_SOCK" && "$SSH_AUTH_SOCK" != "$GPG_AGENT_SSH_SOCK" && $(readlink -f $SSH_AUTH_SOCK) != $GPG_AGENT_SSH_SOCK ]]; then
+          LAUNCHD_SSH_SOCK=$(command -v launchctl &>/dev/null && launchctl getenv SSH_AUTH_SOCK 2>/dev/null)
+          if [[ -n "$SSH_AUTH_SOCK" \
+             && "$SSH_AUTH_SOCK" != "$GPG_AGENT_SSH_SOCK" \
+             && "$SSH_AUTH_SOCK" != "$LAUNCHD_SSH_SOCK" \
+             && $(readlink -f $SSH_AUTH_SOCK) != "$GPG_AGENT_SSH_SOCK" ]]
+          then
             # use ssh signing with the provided key
             export GIT_CONFIG_COUNT=3
             export GIT_CONFIG_KEY_0=gpg.format


### PR DESCRIPTION
TL;DR
-----

Prevents the shell from misidentifying a launchd-provided SSH socket as a remote Prompt session, which incorrectly switched from GPG to SSH signing.

Details
-------

Captures the launchd `SSH_AUTH_SOCK` via `launchctl getenv` and excludes it from the conditional that detects remote SSH agent connections (Prompt on iOS). Without this, a local macOS session with a launchd-managed socket would match the "not GPG agent" condition and override commit signing to use SSH keys instead of GPG.

Reformats the conditional for readability by splitting it across multiple lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)