### PR TITLE
Adds modern CLI tools to base and development modules

### DIFF
--- a/home/modules/base/default.nix
+++ b/home/modules/base/default.nix
@@ -115,7 +115,10 @@ in {
       ];
     };
 
-    bat.enable = true;
+    bat = {
+      enable = true;
+      config.paging = "never";
+    };
 
     direnv = {
       enable = true;
@@ -214,7 +217,7 @@ in {
       };
       
       shellAliases = {
-        cat = "bat --paging=never";
+        cat = "bat";
         more = "less -X";
         pd = "pushd";
         pop = "popd";

--- a/home/modules/base/default.nix
+++ b/home/modules/base/default.nix
@@ -31,9 +31,7 @@ in {
 
     # Basic packages for all environments
     packages = with pkgs; [
-      bat
       dogdns
-      eza
       fd
       moreutils
       nmap
@@ -116,7 +114,9 @@ in {
         "--disable-up-arrow"
       ];
     };
-    
+
+    bat.enable = true;
+
     direnv = {
       enable = true;
       enableZshIntegration = true;
@@ -124,7 +124,14 @@ in {
       enableFishIntegration = true;
       nix-direnv.enable = true;
     };
-    
+
+    eza = {
+      enable = true;
+      enableZshIntegration = true;
+      enableBashIntegration = true;
+      enableFishIntegration = true;
+    };
+
     fzf = {
       enable = true;
       enableZshIntegration = false;
@@ -207,6 +214,7 @@ in {
       };
       
       shellAliases = {
+        cat = "bat --paging=never";
         more = "less -X";
         pd = "pushd";
         pop = "popd";
@@ -291,6 +299,16 @@ in {
 
           function window() {
             smug-session window
+          }
+
+          function sed() {
+            echo "hint: consider 'sd' for cross-platform find-and-replace" >&2
+            command sed "$@"
+          }
+
+          function find() {
+            echo "hint: consider 'fd' for a faster, simpler file finder" >&2
+            command find "$@"
           }
         '')
       ];

--- a/home/modules/base/default.nix
+++ b/home/modules/base/default.nix
@@ -32,6 +32,7 @@ in {
     # Basic packages for all environments
     packages = with pkgs; [
       dogdns
+      fd
       moreutils
       nmap
       pstree

--- a/home/modules/base/default.nix
+++ b/home/modules/base/default.nix
@@ -31,13 +31,16 @@ in {
 
     # Basic packages for all environments
     packages = with pkgs; [
+      bat
       dogdns
+      eza
       fd
       moreutils
       nmap
       pstree
       rar
       ripgrep
+      sd
       sipcalc
       smug
       tcptraceroute

--- a/home/modules/development/default.nix
+++ b/home/modules/development/default.nix
@@ -52,7 +52,9 @@ in {
     
     git = {
       enable = true;
-      
+
+      delta.enable = true;
+
       signing = {
         key = "0805EEDF0FEA6ACD";
         signByDefault = true;

--- a/home/modules/development/default.nix
+++ b/home/modules/development/default.nix
@@ -7,6 +7,7 @@ in {
   # Development-related packages
   home = {
     packages = with pkgs; [
+      ast-grep
       unstable.cue
       exercism
       gh
@@ -21,6 +22,7 @@ in {
       pixi
       shellcheck
       subversion
+      tokei
     ] ++ lib.optionals isDarwin [
     ];
 


### PR DESCRIPTION
TL;DR
-----

Adds `bat`, `eza`, `fd`, `sd`, `tokei`, `ast-grep`, and `delta` to the appropriate home-manager modules, wires up shell integration and a few sensible defaults, and nudges toward the modern tools where syntax diverges from the classics.

Details
-------

Splits the new tooling by scope. Places `fd`, `sd`, `bat`, and `eza` in the base module alongside the existing `ripgrep` — these are general-purpose replacements useful in any interactive shell. Places `tokei` and `ast-grep` in the development module with the rest of the code-analysis tooling (`shellcheck`, `git-filter-repo`, `gh`, and friends) since they only pull weight while working on code.

Wires `bat` and `eza` through their home-manager program modules rather than leaving them as bare packages. `programs.eza` generates the standard `ls`/`ll`/`la`/`lt` aliases across zsh, bash, and fish automatically, matching the integration pattern already used by `fzf`, `atuin`, `zoxide`, and `direnv` in this module. Sets `programs.bat.config.paging = "never"` so `bat` skips its pager by default — if a pager is wanted, reach for `less` explicitly.

Aliases `cat` to `bat` since paging is off, making it a safe drop-in. Leaves `sed` and `find` unaliased because their syntax differs meaningfully from `sd` and `fd`, which would make silent aliasing a footgun. Instead, adds zsh functions that print a one-line hint to stderr pointing at the modern alternative before delegating to the real command via `command sed` / `command find`, training finger memory without breaking anything.

Enables `programs.git.delta` for diff rendering rather than adding `delta` as a bare package. The program module writes the git config required to route diffs and blames through delta automatically, so no manual pager wiring is needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)