### PR TITLE
Restores Replicated and KOTS CLI update workflows

### DIFF
--- a/.github/workflows/update-kots.yml
+++ b/.github/workflows/update-kots.yml
@@ -29,16 +29,12 @@ jobs:
         run: |
           nix-shell -p python3 python3Packages.requests --run "python3 .github/scripts/update-package.py kots"
 
-  calculate-hash:
+  calculate-darwin-hash:
     needs: check-update
     if: needs.check-update.outputs.updated == 'true'
-    strategy:
-      matrix:
-        os: [ubuntu-latest, macos-latest]
-    runs-on: ${{ matrix.os }}
+    runs-on: macos-latest
     outputs:
-      darwin-hash: ${{ steps.vendor.outputs.darwin-hash }}  # legacy
-      linux-hash: ${{ steps.vendor.outputs.linux-hash }}  # legacy
+      darwin-hash: ${{ steps.vendor.outputs.darwin-hash }}
 
     steps:
       - name: Checkout repository
@@ -53,19 +49,54 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.24'
+          go-version: 'stable'
 
       - name: Calculate vendor hash for darwin
         id: vendor
+        env:
+          GOTOOLCHAIN: auto
         run: |
-          nix-shell -p python3 python3Packages.requests --run "python3 .github/scripts/calculate-go-vendor-hash.py kots ${{ needs.check-update.outputs.new-version }} ${{ matrix.os }}"
+          nix-shell -p python3 python3Packages.requests --run "python3 .github/scripts/calculate-go-vendor-hash.py kots ${{ needs.check-update.outputs.new-version }} macos-latest"
+
+      - name: Test KOTS installation
+        run: |
+          .github/scripts/test-package.sh kots
+
+  calculate-linux-hash:
+    needs: check-update
+    if: needs.check-update.outputs.updated == 'true'
+    runs-on: ubuntu-latest
+    outputs:
+      linux-hash: ${{ steps.vendor.outputs.linux-hash }}
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Install Nix
+        uses: DeterminateSystems/nix-installer-action@main
+
+      - name: Setup Nix cache
+        uses: DeterminateSystems/magic-nix-cache-action@main
+
+      - name: Install Go
+        uses: actions/setup-go@v6
+        with:
+          go-version: 'stable'
+
+      - name: Calculate vendor hash for linux
+        id: vendor
+        env:
+          GOTOOLCHAIN: auto
+        run: |
+          nix-shell -p python3 python3Packages.requests --run "python3 .github/scripts/calculate-go-vendor-hash.py kots ${{ needs.check-update.outputs.new-version }} ubuntu-latest"
 
       - name: Test KOTS installation
         run: |
           .github/scripts/test-package.sh kots
 
   update-and-create-pr:
-    needs: [check-update, calculate-hash]
+    needs: [check-update, calculate-darwin-hash, calculate-linux-hash]
     if: needs.check-update.outputs.updated == 'true'
     runs-on: ubuntu-latest
     permissions:
@@ -85,8 +116,8 @@ jobs:
       - name: Update vendorHash values
         run: |
           # Get the vendor hashes from the job outputs
-          DARWIN_HASH="${{ needs.calculate-hash.outputs.darwin-hash }}"
-          LINUX_HASH="${{ needs.calculate-hash.outputs.linux-hash }}"
+          DARWIN_HASH="${{ needs.calculate-darwin-hash.outputs.darwin-hash }}"
+          LINUX_HASH="${{ needs.calculate-linux-hash.outputs.linux-hash }}"
           
           echo "Updating KOTS vendorHash values:"
           echo "Darwin: $DARWIN_HASH"

--- a/.github/workflows/update-replicated.yml
+++ b/.github/workflows/update-replicated.yml
@@ -29,15 +29,44 @@ jobs:
         run: |
           nix-shell -p python3 python3Packages.requests --run "python3 .github/scripts/update-package.py replicated"
 
-  calculate-hash:
+  calculate-darwin-hash:
     needs: check-update
     if: needs.check-update.outputs.updated == 'true'
-    strategy:
-      matrix:
-        os: [ubuntu-latest, macos-latest]
-    runs-on: ${{ matrix.os }}
+    runs-on: macos-latest
     outputs:
       darwin-hash: ${{ steps.vendor.outputs.darwin-hash }}
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Install Nix
+        uses: DeterminateSystems/nix-installer-action@main
+
+      - name: Setup Nix cache
+        uses: DeterminateSystems/magic-nix-cache-action@main
+
+      - name: Install Go
+        uses: actions/setup-go@v6
+        with:
+          go-version: 'stable'
+
+      - name: Calculate vendor hash for darwin
+        id: vendor
+        env:
+          GOTOOLCHAIN: auto
+        run: |
+          nix-shell -p python3 python3Packages.requests --run "python3 .github/scripts/calculate-go-vendor-hash.py replicated ${{ needs.check-update.outputs.new-version }} macos-latest"
+
+      - name: Test Replicated installation
+        run: |
+          .github/scripts/test-package.sh replicated
+
+  calculate-linux-hash:
+    needs: check-update
+    if: needs.check-update.outputs.updated == 'true'
+    runs-on: ubuntu-latest
+    outputs:
       linux-hash: ${{ steps.vendor.outputs.linux-hash }}
 
     steps:
@@ -53,19 +82,21 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.24'
+          go-version: 'stable'
 
-      - name: Calculate vendor hash for darwin
+      - name: Calculate vendor hash for linux
         id: vendor
+        env:
+          GOTOOLCHAIN: auto
         run: |
-          nix-shell -p python3 python3Packages.requests --run "python3 .github/scripts/calculate-go-vendor-hash.py replicated ${{ needs.check-update.outputs.new-version }} macos-latest"
+          nix-shell -p python3 python3Packages.requests --run "python3 .github/scripts/calculate-go-vendor-hash.py replicated ${{ needs.check-update.outputs.new-version }} ubuntu-latest"
 
       - name: Test Replicated installation
         run: |
           .github/scripts/test-package.sh replicated
 
   update-and-create-pr:
-    needs: [check-update, calculate-hash]
+    needs: [check-update, calculate-darwin-hash, calculate-linux-hash]
     if: needs.check-update.outputs.updated == 'true'
     runs-on: ubuntu-latest
     permissions:
@@ -85,8 +116,8 @@ jobs:
       - name: Update vendorHash values
         run: |
           # Get the vendor hashes from the job outputs
-          DARWIN_HASH="${{ needs.calculate-hash.outputs.darwin-hash }}"
-          LINUX_HASH="${{ needs.calculate-hash.outputs.linux-hash }}"
+          DARWIN_HASH="${{ needs.calculate-darwin-hash.outputs.darwin-hash }}"
+          LINUX_HASH="${{ needs.calculate-linux-hash.outputs.linux-hash }}"
           
           echo "Updating Replicated vendorHash values:"
           echo "Darwin: $DARWIN_HASH"


### PR DESCRIPTION
TL;DR
-----

Fixes the `update-replicated.yml` and `update-kots.yml` workflows that have been failing for 2+ days due to a Go version pin and a broken matrix strategy for hash calculation.

Details
-------

Bumps `go-version` from `'1.24'` to `'stable'` and adds `GOTOOLCHAIN: auto` to the hash calculation steps. The `replicated` repo now requires Go >= 1.26.1, but the Nix installer sets `GOTOOLCHAIN=local` which prevents auto-downloading a newer toolchain — the combination of `stable` and `auto` keeps the workflows current without manual version bumps.

Splits the single `calculate-hash` matrix job into two explicit jobs: `calculate-darwin-hash` on `macos-latest` and `calculate-linux-hash` on `ubuntu-latest`. The matrix approach was structurally broken — GitHub Actions doesn't merge outputs across matrix legs, so whichever leg finished last overwrote the other's output. Each leg only ever set one of `darwin-hash` or `linux-hash`, leaving the other empty. Separate jobs eliminate the aggregation bug and make the output wiring obvious.

Fixes the `replicated` workflow's hash calculation script call, which hardcoded `macos-latest` on both matrix legs instead of using `${{ matrix.os }}`. The linux leg now correctly passes `ubuntu-latest` to the hash calculation script.

Updates `update-and-create-pr` to reference `needs.calculate-darwin-hash` and `needs.calculate-linux-hash` for both the `sed` replacements and the PR body template — matching the job names that the PR body was already (prematurely) referencing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)