### PR TITLE
Replays version update in PR job

### DIFF
--- a/.github/workflows/update-kots.yml
+++ b/.github/workflows/update-kots.yml
@@ -113,20 +113,26 @@ jobs:
       - name: Setup Nix cache
         uses: DeterminateSystems/magic-nix-cache-action@main
 
+      - name: Update version and source hash
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          nix-shell -p python3 python3Packages.requests --run "python3 .github/scripts/update-package.py kots"
+
       - name: Update vendorHash values
         run: |
           # Get the vendor hashes from the job outputs
           DARWIN_HASH="${{ needs.calculate-darwin-hash.outputs.darwin-hash }}"
           LINUX_HASH="${{ needs.calculate-linux-hash.outputs.linux-hash }}"
-          
+
           echo "Updating KOTS vendorHash values:"
           echo "Darwin: $DARWIN_HASH"
           echo "Linux: $LINUX_HASH"
-          
+
           # Update the package file with new vendor hashes
           sed -i.bak -E "s|(vendorHash = if isDarwin then[[:space:]]*)\\\".+\\\"|\1\"$DARWIN_HASH\"|" pkgs/kots/default.nix
           sed -i.bak -E "s|(else[[:space:]]*)\\\".+\\\";|\1\"$LINUX_HASH\";|" pkgs/kots/default.nix
-          
+
           # Show the changes
           echo "Updated package file:"
           cat pkgs/kots/default.nix | grep -A3 -B1 vendorHash

--- a/.github/workflows/update-replicated.yml
+++ b/.github/workflows/update-replicated.yml
@@ -113,20 +113,26 @@ jobs:
       - name: Setup Nix cache
         uses: DeterminateSystems/magic-nix-cache-action@main
 
+      - name: Update version and source hash
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          nix-shell -p python3 python3Packages.requests --run "python3 .github/scripts/update-package.py replicated"
+
       - name: Update vendorHash values
         run: |
           # Get the vendor hashes from the job outputs
           DARWIN_HASH="${{ needs.calculate-darwin-hash.outputs.darwin-hash }}"
           LINUX_HASH="${{ needs.calculate-linux-hash.outputs.linux-hash }}"
-          
+
           echo "Updating Replicated vendorHash values:"
           echo "Darwin: $DARWIN_HASH"
           echo "Linux: $LINUX_HASH"
-          
+
           # Update the package file with new vendor hashes
           sed -i.bak -E "s|(vendorHash = if isDarwin then[[:space:]]*)\\\".+\\\"|\1\"$DARWIN_HASH\"|" pkgs/replicated/default.nix
           sed -i.bak -E "s|(else[[:space:]]*)\\\".+\\\";|\1\"$LINUX_HASH\";|" pkgs/replicated/default.nix
-          
+
           # Show the changes
           echo "Updated package file:"
           cat pkgs/replicated/default.nix | grep -A3 -B1 vendorHash


### PR DESCRIPTION
TL;DR
-----

Adds a version update step to the `update-and-create-pr` job so the PR actually contains a diff.

Details
-------

Follows up on #264. The `check-update` job runs `update-package.py` which updates the version and source hash in `default.nix`, but those changes live on an ephemeral runner. The `update-and-create-pr` job does a fresh checkout from `main`, then only runs `sed` to update vendor hashes — which match the old version's existing values, producing an empty diff and no PR.

Re-runs `update-package.py` in `update-and-create-pr` before the vendor hash `sed` replacements. The script is idempotent (GitHub API call + `nix-prefetch-url`), so the redundant call in `check-update` is harmless — it still serves its purpose of detecting whether an update exists and outputting the version metadata that gates downstream jobs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)