### PR TITLE
Corrects zsh vi mode

### DIFF
--- a/home/modules/base/zsh.nix
+++ b/home/modules/base/zsh.nix
@@ -47,8 +47,8 @@ in {
         fpath+=($HOME/workspace/oh-my-zsh-custom/completions)
       '')
 
-      # Shell options
-      (lib.mkOrder 600 ''
+      # Shell options - after oh-my-zsh (mkOrder 800) so vi mode is not overridden
+      (lib.mkOrder 850 ''
         setopt vi
         setopt nobeep
         setopt inc_append_history


### PR DESCRIPTION
TL;DR
-----

Fixes vi mode in zsh by reordering shell options to run after oh-my-zsh.

Details
-------

Moves the shell options block from `mkOrder 600` to `mkOrder 850`. Oh-my-zsh
sources at `mkOrder 800` and resets the keymap to emacs, overriding `setopt vi`.
Running shell options after oh-my-zsh ensures vi mode sticks.