### PR TITLE
Exposes environment variables to macOS GUI apps via declarative launchd system

### DIFF
--- a/docs/research/2025-10-18-darwin-desktop-app-environment.md
+++ b/docs/research/2025-10-18-darwin-desktop-app-environment.md
@@ -1,0 +1,327 @@
+---
+date: 2025-10-18T15:43:27+0000
+researcher: Claude Code
+git_commit: 5c08c54ff6293d144cdf36128a18914dd8286cb1
+branch: feature/crdant/provides-env-for-apps
+repository: dotfiles
+topic: "Making Terminal Environment Variables Available to Desktop Apps on Darwin"
+tags: [research, codebase, darwin, macos, environment-variables, gui-apps, nix-darwin, home-manager]
+status: complete
+last_updated: 2025-10-18
+last_updated_by: Claude Code
+---
+
+# Research: Making Terminal Environment Variables Available to Desktop Apps on Darwin
+
+**Date**: 2025-10-18T15:43:27+0000
+**Researcher**: Claude Code
+**Git Commit**: 5c08c54ff6293d144cdf36128a18914dd8286cb1
+**Branch**: feature/crdant/provides-env-for-apps
+**Repository**: dotfiles
+
+## Research Question
+
+How can environment variables that are currently available in terminal environments be made available to Desktop/GUI applications on Darwin (macOS)?
+
+## Summary
+
+This codebase uses **nix-darwin** and **Home Manager** for declarative system configuration. Currently, environment variables are primarily configured for shell sessions via:
+- `home.sessionVariables` (user-level, cross-shell)
+- `home.sessionPath` (PATH modifications)
+- `programs.zsh.envExtra` (shell-specific environment setup)
+
+**Key Finding**: The codebase does **not** currently have a mechanism to propagate terminal environment variables to GUI/Desktop applications on macOS. The traditional macOS approach would use `launchd` or `~/.MacOSX/environment.plist`, but this codebase uses nix-darwin's declarative system management instead.
+
+**Solution Path**: To make environment variables available to GUI apps, you should use **nix-darwin's `launchd.user.agents`** or configure system-level environment variables that are inherited by GUI applications at login.
+
+## Detailed Findings
+
+### Current Environment Variable Configuration
+
+#### User-Level Session Variables
+**File**: `home/modules/base/default.nix:14-19`
+
+The primary mechanism for setting user environment variables:
+
+```nix
+home = {
+  sessionVariables = {
+    EDITOR = "nvim";
+    VISUAL = "nvim";
+    NIXPKGS_ALLOW_UNFREE = 1;
+    NIXPKGS_ALLOW_BROKEN = 1;
+  };
+};
+```
+
+**Scope**: These variables are available in shell sessions (zsh, bash, fish) but **NOT** automatically available to GUI applications.
+
+#### Shell-Specific Environment Variables
+**File**: `home/modules/base/default.nix:278-288`
+
+More complex environment setup using ZSH:
+
+```nix
+programs = {
+  zsh = {
+    envExtra = ''
+      export XDG_CONFIG_HOME="${config.xdg.configHome}"
+
+      if [[ -d $HOME/.rd ]] ; then
+        export PATH=$PATH:"$HOME/.rd/bin"
+      fi
+
+      unset RPS1
+    '';
+  };
+};
+```
+
+**Scope**: Only available in ZSH sessions, not to GUI applications.
+
+#### Module-Specific Variables
+Multiple modules define their own environment variables:
+- `home/modules/infrastructure/default.nix:37-43` - GOVC_URL, GOVC_USERNAME, etc.
+- `home/modules/ai/default.nix:67-74` - CLAUDE_CONFIG_DIR
+- `home/modules/certificates/default.nix:40-42` - CERTBOT_ROOT
+- `home/modules/kubernetes/default.nix` - K8s-related variables
+
+**Scope**: Shell sessions only.
+
+### System-Level Configuration
+
+#### System Environment Variables
+**File**: `systems/modules/base/terminfo.nix:67-69`
+
+```nix
+environment.variables = {
+  TERMINFO_DIRS = "${pkgs.ncurses}/share/terminfo";
+};
+```
+
+**Note**: `environment.variables` in nix-darwin sets system-wide environment variables, but the current usage is minimal and focused on terminal-specific settings.
+
+#### Desktop Module
+**File**: `systems/modules/desktop/default.nix:55-70`
+
+The desktop module manages GUI applications via Homebrew:
+
+```nix
+environment = {
+  systemPackages = with pkgs; [
+    espanso
+    slack
+    zoom-us
+    # ... more GUI apps
+  ];
+};
+```
+
+**Finding**: No environment variable configuration specific to GUI applications.
+
+### No Traditional macOS Environment Mechanisms Found
+
+**Traditional approaches NOT in use:**
+1. **`~/.MacOSX/environment.plist`** - Not found or configured
+2. **launchd agents for environment** - Not configured
+3. **`/etc/launchd.conf`** - Deprecated on modern macOS, not used
+4. **Login hooks** - Not configured
+
+**Why**: This codebase uses nix-darwin's declarative approach, which avoids imperative configuration files.
+
+## Architecture Insights
+
+### Current Architecture
+```
+┌─────────────────────────────────────┐
+│   Shell Sessions (zsh/bash/fish)   │
+│                                     │
+│  ✓ home.sessionVariables           │
+│  ✓ home.sessionPath                │
+│  ✓ programs.zsh.envExtra           │
+│  ✓ Module-specific env vars        │
+└─────────────────────────────────────┘
+         ↑
+         │ Available in shells
+         │
+┌─────────────────────────────────────┐
+│      Terminal Applications          │
+│  (nvim, git, kubectl, etc.)         │
+└─────────────────────────────────────┘
+
+         ✗ NOT available ✗
+
+┌─────────────────────────────────────┐
+│      GUI/Desktop Applications       │
+│  (Slack, VS Code, Browsers, etc.)   │
+└─────────────────────────────────────┘
+```
+
+### Nix-Darwin Configuration Flow
+```
+flake.nix (Entry point)
+    ↓
+darwinConfigurations.{host}
+    ↓
+systems/hosts/{host}/default.nix
+    ↓
+systems/modules/{various}/default.nix
+    ↓
+nix-darwin system configuration
+    (system.defaults, environment, etc.)
+```
+
+### Home Manager Configuration Flow
+```
+flake.nix (Entry point)
+    ↓
+homeConfigurations.{user}@{host}
+    ↓
+home/users/{user}/{profile}.nix
+    ↓
+home/modules/{various}/default.nix
+    ↓
+home-manager user configuration
+    (home.sessionVariables, programs.*, etc.)
+```
+
+## Recommended Solutions
+
+### Option 1: System-Wide Environment Variables (Simplest)
+
+For variables that should be available everywhere (shells + GUI apps), use nix-darwin's system-level environment configuration.
+
+**File to modify**: Create or modify a system module (e.g., `systems/modules/environment/default.nix`)
+
+```nix
+{ config, pkgs, lib, ... }:
+
+{
+  # System-wide environment variables for GUI and shell apps
+  environment.variables = {
+    # Example: Make these available to all applications
+    MY_VAR = "value";
+    ANOTHER_VAR = "value2";
+  };
+}
+```
+
+**Scope**: Available to both shell sessions and GUI applications after logout/login.
+
+### Option 2: launchd User Agents (More Control)
+
+For more complex scenarios, use nix-darwin's `launchd.user.agents` to set environment variables at user login.
+
+**File to create**: `systems/modules/environment/gui-environment.nix`
+
+```nix
+{ config, pkgs, lib, ... }:
+
+{
+  launchd.user.agents.environment = {
+    serviceConfig = {
+      ProgramArguments = [
+        "${pkgs.bash}/bin/bash"
+        "-c"
+        ''
+          launchctl setenv MY_VAR "value"
+          launchctl setenv PATH "$PATH:/custom/path"
+        ''
+      ];
+      RunAtLoad = true;
+    };
+  };
+}
+```
+
+**Scope**: Runs at user login, sets environment for all user processes including GUI apps.
+
+### Option 3: Per-Application Environment (Most Specific)
+
+For application-specific environment, use home-manager's `home.file` to create application-specific config files.
+
+**Example for VS Code** (`home/modules/development/vscode.nix`):
+
+```nix
+{ config, pkgs, lib, ... }:
+
+{
+  programs.vscode = {
+    enable = true;
+    userSettings = {
+      "terminal.integrated.env.osx" = {
+        MY_VAR = "value";
+      };
+    };
+  };
+}
+```
+
+### Option 4: Hybrid Approach (Recommended)
+
+1. **Core variables** → `environment.variables` (system-level)
+2. **Development tools** → Keep in shell configs for flexibility
+3. **App-specific** → Use app-specific configuration
+
+## Code References
+
+### Key Configuration Files
+- `home/modules/base/default.nix:14-19` - Current sessionVariables
+- `home/modules/base/default.nix:21-30` - Current sessionPath
+- `home/modules/base/default.nix:278-288` - ZSH envExtra
+- `systems/modules/base/terminfo.nix:67-69` - System environment.variables example
+- `systems/modules/desktop/default.nix:55-70` - Desktop applications
+- `flake.nix:61-67` - darwinConfigurations
+
+### Example Modules with Environment Variables
+- `home/modules/infrastructure/default.nix:37-43` - Infrastructure tools
+- `home/modules/ai/default.nix:67-74` - AI tools
+- `home/modules/certificates/default.nix:40-42` - Certificate management
+- `home/modules/kubernetes/default.nix:30-32` - Kubernetes tools
+
+## Implementation Checklist
+
+To make terminal environment variables available to GUI apps:
+
+1. **Identify variables** - Determine which environment variables need to be available to GUI apps
+2. **Choose approach** - Select Option 1, 2, 3, or 4 based on requirements
+3. **Create module** - Create `systems/modules/environment/default.nix` or similar
+4. **Configure variables** - Use `environment.variables` or `launchd.user.agents`
+5. **Import module** - Add module import to system configuration
+6. **Test** - Run `darwin-rebuild switch` and logout/login
+7. **Verify** - Launch a GUI app and check if variables are available
+
+## Open Questions
+
+1. **Which specific environment variables need to be available to GUI apps?**
+   - PATH modifications?
+   - API keys or configuration paths?
+   - Tool-specific variables?
+
+2. **Should all terminal variables be available to GUI apps, or only a subset?**
+   - Security consideration: Some variables might be sensitive
+   - Performance consideration: Some variables might be shell-specific
+
+3. **What's the precedence when combining system and user environment variables?**
+   - nix-darwin's `environment.variables` vs home-manager's `home.sessionVariables`
+
+4. **Are there any GUI applications that currently lack necessary environment variables?**
+   - This would help prioritize which variables to expose
+
+5. **Should this be per-profile or global?**
+   - Consider if different profiles (minimal, development, ai, etc.) need different GUI environments
+
+## Related Resources
+
+- [nix-darwin documentation](https://github.com/LnL7/nix-darwin)
+- [Home Manager manual](https://nix-community.github.io/home-manager/)
+- [macOS launchd documentation](https://developer.apple.com/library/archive/documentation/MacOSX/Conceptual/BPSystemStartup/Chapters/CreatingLaunchdJobs.html)
+- [XDG Base Directory Specification](https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html)
+
+## Next Steps
+
+1. **Discuss requirements** - Determine which variables need GUI access
+2. **Design module structure** - Create a clean, modular solution
+3. **Implement incrementally** - Start with critical variables
+4. **Test thoroughly** - Verify GUI apps receive correct environment
+5. **Document patterns** - Add examples to module documentation

--- a/home/modules/ai/default.nix
+++ b/home/modules/ai/default.nix
@@ -1,4 +1,4 @@
-{ inputs, outputs, config, pkgs, lib, gitEmail, ... }:
+{ inputs, outputs, options, config, pkgs, lib, gitEmail, ... }:
 
 let
   isDarwin = pkgs.stdenv.isDarwin;
@@ -348,6 +348,10 @@ in {
           recursive = true;
         };
       };
+    };
+
+    guiEnvironment = lib.mkIf (options ? guiEnvironment) {
+      CLAUDE_CONFIG_DIR = "${config.xdg.configHome}/claude/personal";
     };
   };
 }

--- a/home/modules/aws/default.nix
+++ b/home/modules/aws/default.nix
@@ -1,6 +1,6 @@
-{ inputs, outputs, config, pkgs, lib, ... }:
+{ inputs, outputs, options, config, pkgs, lib, ... }:
 
-let 
+let
   isDarwin = pkgs.stdenv.isDarwin;
   isLinux = pkgs.stdenv.isLinux;
 in {
@@ -44,4 +44,5 @@ in {
       };
     };
   };
+  guiEnvironment = lib.mkIf (options ? guiEnvironment) {};
 }

--- a/home/modules/aws/default.nix
+++ b/home/modules/aws/default.nix
@@ -44,5 +44,4 @@ in {
       };
     };
   };
-  guiEnvironment = lib.mkIf (options ? guiEnvironment) {};
 }

--- a/home/modules/azure/default.nix
+++ b/home/modules/azure/default.nix
@@ -17,5 +17,4 @@ in {
       };
     };
   };
-  guiEnvironment = lib.mkIf (options ? guiEnvironment) {};
 }

--- a/home/modules/azure/default.nix
+++ b/home/modules/azure/default.nix
@@ -1,6 +1,6 @@
-{ inputs, outputs, config, pkgs, lib, ... }:
+{ inputs, outputs, options, config, pkgs, lib, ... }:
 
-let 
+let
   isDarwin = pkgs.stdenv.isDarwin;
   isLinux = pkgs.stdenv.isLinux;
 in {
@@ -17,4 +17,5 @@ in {
       };
     };
   };
+  guiEnvironment = lib.mkIf (options ? guiEnvironment) {};
 }

--- a/home/modules/base/default.nix
+++ b/home/modules/base/default.nix
@@ -1,10 +1,22 @@
-{ inputs, outputs, config, pkgs, lib, username, homeDirectory, ... }:
+{ inputs, outputs, options, config, pkgs, lib, username, homeDirectory, secretsFile ? null, ... }:
 
 let
   isDarwin = pkgs.stdenv.isDarwin;
   isLinux = pkgs.stdenv.isLinux;
 in {
   imports = [ ./fish.nix ./zsh.nix ];
+
+  # Option for environment variables visible to GUI/desktop apps via launchd
+  options.guiEnvironment = lib.mkOption {
+    type = lib.types.attrsOf lib.types.str;
+    default = {};
+    description = "Environment variables to make visible to GUI/desktop apps via launchd.";
+  };
+
+  config = {
+  guiEnvironment = {
+    XDG_CONFIG_HOME = config.xdg.configHome;
+  };
 
   # Home Manager basics
   home = {
@@ -327,4 +339,5 @@ in {
       };
     };
   };
+  }; # config
 }

--- a/home/modules/base/default.nix
+++ b/home/modules/base/default.nix
@@ -6,17 +6,37 @@ let
 in {
   imports = [ ./fish.nix ./zsh.nix ];
 
-  # Option for environment variables visible to GUI/desktop apps via launchd
   options.guiEnvironment = lib.mkOption {
     type = lib.types.attrsOf lib.types.str;
     default = {};
     description = "Environment variables to make visible to GUI/desktop apps via launchd.";
   };
 
-  config = {
-  guiEnvironment = {
-    XDG_CONFIG_HOME = config.xdg.configHome;
+  options.guiPath = lib.mkOption {
+    type = lib.types.listOf lib.types.str;
+    default = [];
+    description = "PATH entries to make visible to GUI/desktop apps via launchd.";
   };
+
+  config = {
+    guiEnvironment = {
+      XDG_CONFIG_HOME = config.xdg.configHome;
+    };
+
+    guiPath = [
+      "${homeDirectory}/.local/bin"
+      "${homeDirectory}/workspace/go/bin"
+    ] ++ lib.optionals isDarwin [
+      "/opt/homebrew/bin"
+      "/opt/homebrew/sbin"
+    ] ++ [
+      "/usr/local/bin"
+      "/usr/local/sbin"
+      "/usr/bin"
+      "/bin"
+      "/usr/sbin"
+      "/sbin"
+    ];
 
   # Home Manager basics
   home = {
@@ -87,12 +107,16 @@ in {
     };
 
     activation = {
-     workspaceDirectory = lib.hm.dag.entryBefore [ "writeBoundary" ] ''
+      workspaceDirectory = lib.hm.dag.entryBefore [ "writeBoundary" ] ''
         mkdir -p ~/workspace
         mkdir -p ~/sandbox
       '';
 
-      customizeOmz = lib.hm.dag.entryAfter [ "linkGeneration" ] ''
+      launchdLogDirectory = lib.hm.dag.entryBefore [ "writeBoundary" ] ''
+        mkdir -p ${config.xdg.stateHome}/launchd
+      '';
+
+      customizeOmz = lib.hm.dag.entryAfter [ "writeBoundary" "installPackages" "git" ] ''
         if [ ! -d ~/workspace/oh-my-zsh-custom ]; then
           ${pkgs.git}/bin/git clone https://github.com/crdant/oh-my-zsh-custom ~/workspace/oh-my-zsh-custom || {
             echo "Warning: Failed to clone oh-my-zsh-custom repository. Skipping..."
@@ -332,11 +356,18 @@ in {
         source = ./config/smug;
         recursive = true;
       };
-    } // lib.optionalAttrs isDarwin { 
-    } // lib.optionalAttrs isLinux { 
+    } // lib.optionalAttrs isDarwin {
+    } // lib.optionalAttrs isLinux {
       "glow/glow.yml" = {
         text = builtins.readFile ./config/glow/glow.yml;
       };
+    };
+  };
+
+  sops = lib.mkIf (secretsFile != null) {
+    defaultSopsFile = secretsFile;
+    gnupg = {
+      home = "${homeDirectory}/.gnupg";
     };
   };
   }; # config

--- a/home/modules/certificates/default.nix
+++ b/home/modules/certificates/default.nix
@@ -88,5 +88,4 @@ in {
   } else {
     enable = false;
   };
-  guiEnvironment = lib.mkIf (options ? guiEnvironment) {};
 }

--- a/home/modules/certificates/default.nix
+++ b/home/modules/certificates/default.nix
@@ -1,6 +1,6 @@
-{ inputs, outputs, config, pkgs, lib, ... }:
+{ inputs, outputs, options, config, pkgs, lib, ... }:
 
-let 
+let
   isDarwin = pkgs.stdenv.isDarwin;
   isLinux = pkgs.stdenv.isLinux;
 in {
@@ -88,4 +88,5 @@ in {
   } else {
     enable = false;
   };
+  guiEnvironment = lib.mkIf (options ? guiEnvironment) {};
 }

--- a/home/modules/cicd/default.nix
+++ b/home/modules/cicd/default.nix
@@ -19,5 +19,4 @@ in {
   #     enable = true;
   #   };
   # };
-  guiEnvironment = lib.mkIf (options ? guiEnvironment) {};
 }

--- a/home/modules/cicd/default.nix
+++ b/home/modules/cicd/default.nix
@@ -1,6 +1,6 @@
-{ inputs, outputs, config, pkgs, lib, ... }:
+{ inputs, outputs, options, config, pkgs, lib, ... }:
 
-let 
+let
   isDarwin = pkgs.stdenv.isDarwin;
   isLinux = pkgs.stdenv.isLinux;
 in {
@@ -19,4 +19,5 @@ in {
   #     enable = true;
   #   };
   # };
+  guiEnvironment = lib.mkIf (options ? guiEnvironment) {};
 }

--- a/home/modules/containers/default.nix
+++ b/home/modules/containers/default.nix
@@ -31,5 +31,4 @@ in {
       };
     };
   };
-  guiEnvironment = lib.mkIf (options ? guiEnvironment) {};
 }

--- a/home/modules/containers/default.nix
+++ b/home/modules/containers/default.nix
@@ -1,6 +1,6 @@
-{ inputs, outputs, config, pkgs, lib, ... }:
+{ inputs, outputs, options, config, pkgs, lib, ... }:
 
-let 
+let
   isDarwin = pkgs.stdenv.isDarwin;
   isLinux = pkgs.stdenv.isLinux;
 in {
@@ -31,4 +31,5 @@ in {
       };
     };
   };
+  guiEnvironment = lib.mkIf (options ? guiEnvironment) {};
 }

--- a/home/modules/data/default.nix
+++ b/home/modules/data/default.nix
@@ -1,4 +1,4 @@
-{ inputs, outputs, config, pkgs, lib, ... }:
+{ inputs, outputs, options, config, pkgs, lib, ... }:
 
 let
   isDarwin = pkgs.stdenv.isDarwin;
@@ -37,4 +37,5 @@ in {
       };
     };
   };
+  guiEnvironment = lib.mkIf (options ? guiEnvironment) {};
 }

--- a/home/modules/data/default.nix
+++ b/home/modules/data/default.nix
@@ -37,5 +37,4 @@ in {
       };
     };
   };
-  guiEnvironment = lib.mkIf (options ? guiEnvironment) {};
 }

--- a/home/modules/desktop/default.nix
+++ b/home/modules/desktop/default.nix
@@ -4,12 +4,16 @@ let
   isDarwin = pkgs.stdenv.isDarwin;
   isLinux = pkgs.stdenv.isLinux;
   cfg = config.guiEnvironment;
+  guiPath = config.guiPath;
 
-  setenvScript = lib.concatStringsSep "\n" (
-    lib.mapAttrsToList (name: value:
-      "/bin/launchctl setenv ${name} '${value}'"
-    ) cfg
-  );
+  setenvScript =
+    lib.optionalString (guiPath != [])
+      "/bin/launchctl setenv PATH '${lib.concatStringsSep ":" guiPath}'\n" +
+    lib.concatStringsSep "\n" (
+      lib.mapAttrsToList (name: value:
+        "/bin/launchctl setenv ${name} '${value}'"
+      ) cfg
+    );
 
 in {
   # Home Manager basics
@@ -80,7 +84,7 @@ in {
   };
 
   # LaunchAgent to set GUI-visible environment variables on login
-  launchd.agents.set-environment = lib.mkIf (isDarwin && cfg != {}) {
+  launchd.agents.set-environment = lib.mkIf (isDarwin && (cfg != {} || guiPath != [])) {
     enable = true;
     config = {
       Label = "io.shortrib.set-environment";
@@ -94,7 +98,7 @@ in {
   # Dock configuration for Darwin
   home.activation = lib.mkIf isDarwin {
     # Re-trigger the environment agent immediately on activation
-    guiEnvironment = lib.mkIf (cfg != {}) (lib.hm.dag.entryAfter [ "writeBoundary" ] ''
+    guiEnvironment = lib.mkIf (cfg != {} || guiPath != []) (lib.hm.dag.entryAfter [ "writeBoundary" ] ''
       /bin/launchctl kickstart -k gui/$(/usr/bin/id -u)/io.shortrib.set-environment 2>/dev/null || true
     '');
 

--- a/home/modules/desktop/default.nix
+++ b/home/modules/desktop/default.nix
@@ -1,8 +1,16 @@
-{ inputs, outputs, config, pkgs, lib, username, homeDirectory, secretsFile ? null, ... }:
+{ inputs, outputs, options, config, pkgs, lib, username, homeDirectory, secretsFile ? null, ... }:
 
-let 
+let
   isDarwin = pkgs.stdenv.isDarwin;
   isLinux = pkgs.stdenv.isLinux;
+  cfg = config.guiEnvironment;
+
+  setenvScript = lib.concatStringsSep "\n" (
+    lib.mapAttrsToList (name: value:
+      "/bin/launchctl setenv ${name} '${value}'"
+    ) cfg
+  );
+
 in {
   # Home Manager basics
   home = {
@@ -71,8 +79,25 @@ in {
     };
   };
 
+  # LaunchAgent to set GUI-visible environment variables on login
+  launchd.agents.set-environment = lib.mkIf (isDarwin && cfg != {}) {
+    enable = true;
+    config = {
+      Label = "io.shortrib.set-environment";
+      ProgramArguments = [
+        "/bin/bash" "-c" setenvScript
+      ];
+      RunAtLoad = true;
+    };
+  };
+
   # Dock configuration for Darwin
   home.activation = lib.mkIf isDarwin {
+    # Re-trigger the environment agent immediately on activation
+    guiEnvironment = lib.mkIf (cfg != {}) (lib.hm.dag.entryAfter [ "writeBoundary" ] ''
+      /bin/launchctl kickstart -k gui/$(/usr/bin/id -u)/io.shortrib.set-environment 2>/dev/null || true
+    '');
+
     configureDock = lib.hm.dag.entryAfter ["writeBoundary"] ''
       echo "Configuring Dock..."
 
@@ -119,5 +144,8 @@ in {
       echo "Dock configuration complete"
     '';
   };
+  guiEnvironment = lib.mkIf (options ? guiEnvironment) {
+    EDITOR = "nvim";
+    VISUAL = "nvim";
+  };
 }
-

--- a/home/modules/development/default.nix
+++ b/home/modules/development/default.nix
@@ -1,6 +1,6 @@
-{ inputs, outputs, config, pkgs, lib, gitEmail, ... }:
+{ inputs, outputs, options, config, pkgs, lib, gitEmail, ... }:
 
-let 
+let
   isDarwin = pkgs.stdenv.isDarwin;
   isLinux = pkgs.stdenv.isLinux;
 in {
@@ -163,6 +163,7 @@ in {
     };
     
   };
-  
-  
+
+
+  guiEnvironment = lib.mkIf (options ? guiEnvironment) {};
 }

--- a/home/modules/development/default.nix
+++ b/home/modules/development/default.nix
@@ -165,5 +165,4 @@ in {
   };
 
 
-  guiEnvironment = lib.mkIf (options ? guiEnvironment) {};
 }

--- a/home/modules/editor/default.nix
+++ b/home/modules/editor/default.nix
@@ -159,5 +159,4 @@ in {
       '';
     };
   };
-  guiEnvironment = lib.mkIf (options ? guiEnvironment) {};
 }

--- a/home/modules/editor/default.nix
+++ b/home/modules/editor/default.nix
@@ -1,6 +1,6 @@
-{ inputs, outputs, config, pkgs, lib, ... }:
+{ inputs, outputs, options, config, pkgs, lib, ... }:
 
-let 
+let
   isDarwin = pkgs.stdenv.isDarwin;
   isLinux = pkgs.stdenv.isLinux;
 in {
@@ -159,4 +159,5 @@ in {
       '';
     };
   };
+  guiEnvironment = lib.mkIf (options ? guiEnvironment) {};
 }

--- a/home/modules/go/default.nix
+++ b/home/modules/go/default.nix
@@ -14,7 +14,7 @@ in {
     go = {
       enable = true;
       env = {
-        GOPATH = [ "${config.home.homeDirectory}/workspace/go}" ];
+        GOPATH = [ "${config.home.homeDirectory}/workspace/go" ];
       };
       package = pkgs.go;
     };
@@ -57,5 +57,4 @@ in {
       };
     };
   };
-  guiEnvironment = lib.mkIf (options ? guiEnvironment) {};
 }

--- a/home/modules/go/default.nix
+++ b/home/modules/go/default.nix
@@ -1,6 +1,6 @@
-{ inputs, outputs, config, pkgs, lib, ... }:
+{ inputs, outputs, options, config, pkgs, lib, ... }:
 
-let 
+let
   isDarwin = pkgs.stdenv.isDarwin;
   isLinux = pkgs.stdenv.isLinux;
 in {
@@ -57,4 +57,5 @@ in {
       };
     };
   };
+  guiEnvironment = lib.mkIf (options ? guiEnvironment) {};
 }

--- a/home/modules/google/default.nix
+++ b/home/modules/google/default.nix
@@ -1,6 +1,6 @@
-{ inputs, outputs, config, pkgs, lib, ... }:
+{ inputs, outputs, options, config, pkgs, lib, ... }:
 
-let 
+let
   isDarwin = pkgs.stdenv.isDarwin;
   isLinux = pkgs.stdenv.isLinux;
 in {
@@ -18,4 +18,5 @@ in {
       };
     };
   };
+  guiEnvironment = lib.mkIf (options ? guiEnvironment) {};
 }

--- a/home/modules/google/default.nix
+++ b/home/modules/google/default.nix
@@ -18,5 +18,4 @@ in {
       };
     };
   };
-  guiEnvironment = lib.mkIf (options ? guiEnvironment) {};
 }

--- a/home/modules/home-network/default.nix
+++ b/home/modules/home-network/default.nix
@@ -1,4 +1,4 @@
-{ inputs, outputs, config, pkgs, lib, ... }:
+{ inputs, outputs, options, config, pkgs, lib, ... }:
 
 {
   # Homelab-specific SSH configurations
@@ -32,5 +32,6 @@
       };
     };
   };
+  guiEnvironment = lib.mkIf (options ? guiEnvironment) {};
 }
 

--- a/home/modules/home-network/default.nix
+++ b/home/modules/home-network/default.nix
@@ -32,6 +32,5 @@
       };
     };
   };
-  guiEnvironment = lib.mkIf (options ? guiEnvironment) {};
 }
 

--- a/home/modules/homelab/default.nix
+++ b/home/modules/homelab/default.nix
@@ -87,5 +87,4 @@ in {
       };
     };
   };
-  guiEnvironment = lib.mkIf (options ? guiEnvironment) {};
 }

--- a/home/modules/homelab/default.nix
+++ b/home/modules/homelab/default.nix
@@ -1,9 +1,9 @@
-{ inputs, outputs, config, pkgs, lib, ... }:
-let 
+{ inputs, outputs, options, config, pkgs, lib, ... }:
+
+let
   isDarwin = pkgs.stdenv.isDarwin;
   isLinux = pkgs.stdenv.isLinux;
 in {
-
   home = {
     packages = with pkgs; [
       govc
@@ -87,4 +87,5 @@ in {
       };
     };
   };
+  guiEnvironment = lib.mkIf (options ? guiEnvironment) {};
 }

--- a/home/modules/infrastructure/default.nix
+++ b/home/modules/infrastructure/default.nix
@@ -55,5 +55,4 @@ in {
       };
     };
   };
-  guiEnvironment = lib.mkIf (options ? guiEnvironment) {};
 }

--- a/home/modules/infrastructure/default.nix
+++ b/home/modules/infrastructure/default.nix
@@ -1,6 +1,6 @@
-{ inputs, outputs, config, pkgs, lib, ... }:
+{ inputs, outputs, options, config, pkgs, lib, ... }:
 
-let 
+let
   isDarwin = pkgs.stdenv.isDarwin;
   isLinux = pkgs.stdenv.isLinux;
 in {
@@ -55,4 +55,5 @@ in {
       };
     };
   };
+  guiEnvironment = lib.mkIf (options ? guiEnvironment) {};
 }

--- a/home/modules/javascript/default.nix
+++ b/home/modules/javascript/default.nix
@@ -1,6 +1,6 @@
-{ inputs, outputs, config, pkgs, lib, ... }:
+{ inputs, outputs, options, config, pkgs, lib, ... }:
 
-let 
+let
   isDarwin = pkgs.stdenv.isDarwin;
   isLinux = pkgs.stdenv.isLinux;
 in {
@@ -28,4 +28,5 @@ in {
       };
     };
   };
+  guiEnvironment = lib.mkIf (options ? guiEnvironment) {};
 }

--- a/home/modules/javascript/default.nix
+++ b/home/modules/javascript/default.nix
@@ -28,5 +28,4 @@ in {
       };
     };
   };
-  guiEnvironment = lib.mkIf (options ? guiEnvironment) {};
 }

--- a/home/modules/kubernetes/default.nix
+++ b/home/modules/kubernetes/default.nix
@@ -69,5 +69,7 @@ in {
       };
     };
   };
-  guiEnvironment = lib.mkIf (options ? guiEnvironment) {};
+  guiPath = lib.mkIf (options ? guiPath) [
+    "${config.home.homeDirectory}/.krew/bin"
+  ];
 }

--- a/home/modules/kubernetes/default.nix
+++ b/home/modules/kubernetes/default.nix
@@ -1,6 +1,6 @@
-{ inputs, outputs, config, pkgs, lib, ... }:
+{ inputs, outputs, options, config, pkgs, lib, ... }:
 
-let 
+let
   isDarwin = pkgs.stdenv.isDarwin;
   isLinux = pkgs.stdenv.isLinux;
 in {
@@ -69,4 +69,5 @@ in {
       };
     };
   };
+  guiEnvironment = lib.mkIf (options ? guiEnvironment) {};
 }

--- a/home/modules/python/default.nix
+++ b/home/modules/python/default.nix
@@ -1,6 +1,6 @@
-{ inputs, outputs, config, pkgs, lib, ... }:
+{ inputs, outputs, options, config, pkgs, lib, ... }:
 
-let 
+let
   isDarwin = pkgs.stdenv.isDarwin;
   isLinux = pkgs.stdenv.isLinux;
 in {
@@ -28,4 +28,5 @@ in {
       };
     };
   };
+  guiEnvironment = lib.mkIf (options ? guiEnvironment) {};
 }

--- a/home/modules/python/default.nix
+++ b/home/modules/python/default.nix
@@ -28,5 +28,4 @@ in {
       };
     };
   };
-  guiEnvironment = lib.mkIf (options ? guiEnvironment) {};
 }

--- a/home/modules/replicated/default.nix
+++ b/home/modules/replicated/default.nix
@@ -1,6 +1,6 @@
-{ inputs, outputs, config, pkgs, lib, ... }:
+{ inputs, outputs, options, config, pkgs, lib, ... }:
 
-let 
+let
   isDarwin = pkgs.stdenv.isDarwin;
   isLinux = pkgs.stdenv.isLinux;
 in {
@@ -63,5 +63,6 @@ in {
         };
     };
   };
+  guiEnvironment = lib.mkIf (options ? guiEnvironment) {};
 }
 

--- a/home/modules/replicated/default.nix
+++ b/home/modules/replicated/default.nix
@@ -63,6 +63,5 @@ in {
         };
     };
   };
-  guiEnvironment = lib.mkIf (options ? guiEnvironment) {};
 }
 

--- a/home/modules/rust/default.nix
+++ b/home/modules/rust/default.nix
@@ -30,5 +30,7 @@ in {
       };
     };
   };
-  guiEnvironment = lib.mkIf (options ? guiEnvironment) {};
+  guiPath = lib.mkIf (options ? guiPath) [
+    "${config.home.homeDirectory}/.cargo/bin"
+  ];
 }

--- a/home/modules/rust/default.nix
+++ b/home/modules/rust/default.nix
@@ -1,6 +1,6 @@
-{ inputs, outputs, config, pkgs, lib, ... }:
+{ inputs, outputs, options, config, pkgs, lib, ... }:
 
-let 
+let
   isDarwin = pkgs.stdenv.isDarwin;
   isLinux = pkgs.stdenv.isLinux;
 in {
@@ -30,4 +30,5 @@ in {
       };
     };
   };
+  guiEnvironment = lib.mkIf (options ? guiEnvironment) {};
 }

--- a/home/modules/security/default.nix
+++ b/home/modules/security/default.nix
@@ -102,5 +102,7 @@ in {
     };
   };
 
-  guiEnvironment = lib.mkIf (options ? guiEnvironment) {};
+  guiEnvironment = lib.mkIf (options ? guiEnvironment) {
+    SSH_AUTH_SOCK = "${config.home.homeDirectory}/.gnupg/S.gpg-agent.ssh";
+  };
 }

--- a/home/modules/security/default.nix
+++ b/home/modules/security/default.nix
@@ -1,6 +1,6 @@
-{ inputs, outputs, config, pkgs, lib, gitEmail, secretsFile ? null, ... }:
+{ inputs, outputs, options, config, pkgs, lib, gitEmail, secretsFile ? null, ... }:
 
-let 
+let
   isDarwin = pkgs.stdenv.isDarwin;
   isLinux = pkgs.stdenv.isLinux;
 in {
@@ -101,5 +101,6 @@ in {
       
     };
   };
-  
+
+  guiEnvironment = lib.mkIf (options ? guiEnvironment) {};
 }

--- a/home/modules/swift/default.nix
+++ b/home/modules/swift/default.nix
@@ -1,6 +1,6 @@
-{ inputs, outputs, config, pkgs, lib, ... }:
+{ inputs, outputs, options, config, pkgs, lib, ... }:
 
-let 
+let
   isDarwin = pkgs.stdenv.isDarwin;
   isLinux = pkgs.stdenv.isLinux;
 in {
@@ -38,4 +38,5 @@ in {
       };
     };
   };
+  guiEnvironment = lib.mkIf (options ? guiEnvironment) {};
 }

--- a/home/modules/swift/default.nix
+++ b/home/modules/swift/default.nix
@@ -38,5 +38,4 @@ in {
       };
     };
   };
-  guiEnvironment = lib.mkIf (options ? guiEnvironment) {};
 }


### PR DESCRIPTION
TL;DR
-----

macOS GUI apps (editors, IDEs, anything launched outside a terminal) don't inherit the environment configured through home-manager. This PR introduces two declarative module options -- `guiEnvironment` (`attrsOf str`) and `guiPath` (`listOf str`) -- that any module can contribute to, backed by a single launchd agent in the desktop module that applies all values on login and on each home-manager activation.

Supersedes crdant/dotfiles#206.

Details
-------

**One agent, not many.** The prior approach (crdant/dotfiles#206) added a separate launchd agent per module (`io.crdant.env.base`, `io.crdant.env.ai`, `io.crdant.env.kubernetes`). This PR consolidates to one agent (`io.shortrib.set-environment`) owned by the desktop module, which reads all contributed values at evaluation time. One agent, one place to reason about what's set.

**`guiPath` as a list, not a string.** PATH is the one variable that multiple modules naturally want to extend. An `attrsOf str` key would have the last writer win. A `listOf str` option merges by concatenation, so kubernetes contributes `~/.krew/bin` and rust contributes `~/.cargo/bin` without either clobbering the base paths defined in the base module.

**Contributions are per-module.** Base seeds standard paths and `XDG_CONFIG_HOME`. Security contributes `SSH_AUTH_SOCK`. AI contributes `CLAUDE_CONFIG_DIR`. Desktop contributes `EDITOR` and `VISUAL`. Kubernetes and rust each add a bin directory to `guiPath`. Modules with nothing to expose carry no stub.

The PR also restores `sops` wiring and `launchdLogDirectory` activation dropped during earlier restructuring, corrects the `customizeOmz` activation dependency from `linkGeneration` to `[ "writeBoundary" "installPackages" "git" ]`, and fixes a stray `}` in the go module's `GOPATH` string.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Claude Sonnet 4.6 (200K)](https://img.shields.io/badge/Claude_Sonnet_4.6_%28200K%29-D97757?logo=claude&logoColor=white)