### PR TITLE
Refreshes and new atproto module for May/June 2026

### DIFF
--- a/home/modules/atproto/default.nix
+++ b/home/modules/atproto/default.nix
@@ -1,0 +1,24 @@
+{ inputs, outputs, options, config, pkgs, lib, ... }:
+
+let
+  isDarwin = pkgs.stdenv.isDarwin;
+  isLinux = pkgs.stdenv.isLinux;
+in {
+  home.packages = with pkgs; [
+    unstable.atproto-goat
+  ];
+
+  sops.secrets."atproto/pds/adminPassword" = {};
+
+  home.sessionVariables = {
+    PDS_HOST = "pds.shortrib.io";
+  };
+
+  programs.zsh.envExtra = ''
+    export PDS_ADMIN_PASSWORD="$(cat ${config.sops.secrets."atproto/pds/adminPassword".path})"
+  '';
+
+  programs.fish.shellInit = ''
+    set -gx PDS_ADMIN_PASSWORD (cat ${config.sops.secrets."atproto/pds/adminPassword".path})
+  '';
+}

--- a/home/modules/development/default.nix
+++ b/home/modules/development/default.nix
@@ -20,6 +20,7 @@ in {
       nix-init
       nix-prefetch-git
       pixi
+      railway
       shellcheck
       subversion
       tokei

--- a/home/modules/replicated/default.nix
+++ b/home/modules/replicated/default.nix
@@ -14,7 +14,7 @@ in {
     ] ++ lib.optionals isDarwin [
       instruqt
       iterm2
-      teams
+      # teams
     ];
     file = lib.optionalAttrs isDarwin {
       "Library/Colors/Replicated.clr" = {

--- a/home/profiles/full.nix
+++ b/home/profiles/full.nix
@@ -1,6 +1,7 @@
 { pkgs, ... }: {
   # Full workstation profile with all modules
   imports = [
+    ../modules/atproto
     ../modules/base
     ../modules/desktop
     ../modules/development

--- a/home/users/crdant/darwin.nix
+++ b/home/users/crdant/darwin.nix
@@ -19,7 +19,6 @@ in
 {
   homebrew = {
     taps = [
-      "humanlayer/humanlayer"
       "steipete/tap"
     ];
     brews = [
@@ -36,7 +35,6 @@ in
       "arc"
       "beeper"
       "claude"
-      "codelayer"
       "discord"
       "lens"
       "loom"
@@ -44,10 +42,8 @@ in
       "postman"
       "raspberry-pi-imager"
       "repobar"
-      "macwhisper"
+      "microsoft-teams"
       "monologue"
-      "notion-calendar"
-      "snowflake-snowsql"
       "superhuman"
       "thebrowsercompany-dia"
     ];

--- a/home/users/crdant/secrets.yaml
+++ b/home/users/crdant/secrets.yaml
@@ -1,65 +1,68 @@
 github:
-    token: ENC[AES256_GCM,data:a5AWCXJi0XokcqV6FjyZjFOQ0F/vvsTLoyhfj3NcZhpevpzRhNTbpw==,iv:xggWtEbsNrziC06kpdA7Ymz5zl8xo6JcMk+qwgCVqIM=,tag:Wdl9mmaOrkBLk4LeA3ev6g==,type:str]
+    token: ENC[AES256_GCM,data:38/h/WJadwPBm1WRsJzyFXQPBccYvKXhox2XhJ9nLoe0Mj2Ebrxc6w==,iv:pqkLZ5RQbJ5qrpg0iO7+aEa3VHuj4XL5mJKg+c+ia5U=,tag:+prMiNXMh8c9nNw8Vr4p0Q==,type:str]
 anthropic:
     apiKeys:
-        chuck@replicated.com: ENC[AES256_GCM,data:c6y/+zHlIgBCoCd70ztzu1NoRsfCFcOK84huBvK9l5f0O9Oc+0xDK1bZmeqgMeEovfwwXpgzXPb8lpLSnu+CyPbTQVDjUtZGwWFmssH8W0Ko9ngdSVY0zomnybKWsw80jNFMmeAceVswZy4=,iv:vWNKya9xS3+rl2410wgLrpQJw8fIpCtkgJvJAIwCE/M=,tag:IZXPHodudGF7Npk8PouJng==,type:str]
-        chuck@crdant.io: ENC[AES256_GCM,data:+DWvsLEGDIZxuk3DiQssKDF8uzOIbPlX2wXyXjo+Mc/FjYa2G4y8Z9dYioCDZz/DWWpJZSmrlVrmZ9FyHjq7/3qdOjKivjfsPetMVYObo6lNhK5fiDYV2rfgv+W6Fmtmn32XcdsahVbUDLdr,iv:mdfjpjS6O5EGEYj5BfFW4bVqCBWTVNYQq5klPhLYUFk=,tag:CXf1IRueu2EuGoKoKaJTQA==,type:str]
+        chuck@replicated.com: ENC[AES256_GCM,data:EVK4hyLatOjjeYERZyGfHVJGsHBjCohs0WdOfEUQrSWaidDMb40R6+cBEA9pAESwphB2Rvj9lJPvBKVNyKEF4521Em4F6tuIdPLbbruWzMx9FtOI3prEdN5QGz+0keLRF9yLGTNkIwA8ULY=,iv:ZdMecYxtkYytNMmBkB/Zs2hNLl7bSQpzTpyRgGhvZO4=,tag:DGX+xdfh+pvJBZzrHfZWQg==,type:str]
+        chuck@crdant.io: ENC[AES256_GCM,data:uq9AybpPIdcJbfO9ITkgo/U57Asir4qyjVU+RVR2SPrEhzvbNvjyPxTyGGMxkuoTKv1CT03HnbdkfQjEKcjAO67PYnhm+9ip7RX/yx8gD0NUx/GPlb4m4c71WPiMPPOtH5IIXqI3qN25xab8,iv:K55V61VhjmiDOso05r+h3OBluTLfsx9Iv381GsoVW1A=,tag:tahyIUL36uwQq3fxfdyGHg==,type:str]
 google:
     maps:
-        apiKey: ENC[AES256_GCM,data:gvVp2RBJ1AmJFObLLspFGML+s8BaidfQUXuBf9Nn6bdcPEvPrp7Q,iv:lFoDEKMIGNy3HcPheCC7Qol3WkvprJPHdoXq9oZwTek=,tag:DmL9VH3RU2ZyJyN7SgsgwA==,type:str]
+        apiKey: ENC[AES256_GCM,data:Fu6X/mDR3mMHVstacw3D77aVk5q4G26YMFm7InyfL5xZJGIAbfbD,iv:fkAFXiJ3IFUPIC+OXpgD1wzeQAL9+fqfIQQySE6Q7cM=,tag:RdxdhkB0BEV57q3eb5Si9w==,type:str]
 slack:
     shortrib:
         slackernews:
-            userToken: ENC[AES256_GCM,data:xgjAyAmZpwz9pJ/2BV/WEhZSzDKkp2cjq7GjPsHMAQxVQ3Xc4lMz8tOApbh1oTfjqhTsxbhjtYRO5kceSdLFVQDGzB5PoeGohFkR4xLgXg==,iv:XMUh+1R7A+TmMgqhuuaq+STO7o+A2JNUc8CO27jlLhI=,tag:0kT7zzo3kpUog5F6h2Bedg==,type:str]
-            botToken: ENC[AES256_GCM,data:+wv6ZUZ/45geKP7BqfXwMqVCqdsdxTGUgF2qXN5cS1DOYABIPdTn7BR4eVVahA5hShad0oXqsx0A,iv:i0DaoKcpUpWgX5yvA3Ct+L/+JxnVSFVNVmeKIOmyC9U=,tag:ddpvj2wW39qy1vKRwNlGGQ==,type:str]
+            userToken: ENC[AES256_GCM,data:q61rSwNFU7Wmw7jMfQxW0QBFyrXs2vx4loMENAa6l6LT+e93e7K6Pe3fL1WHgy3pY384uWb5uz3wVjgJag/EZPphq/DlbZxstNEY5KRXdg==,iv:Kp57ZiJJSdZyDruaheIfndVihifGjOOfK9bzl9BmM9w=,tag:UybrOK/3uAdj2ZQ4IsSDpw==,type:str]
+            botToken: ENC[AES256_GCM,data:fJWINXv9ZP9YiMFBhc4Elo+k3emc2t9vE1+n+Vh7OGIPJoIpdNCoU05JA5OGEbwpVSMjNukANYX6,iv:W/rf52+XZtOn4FBho1T3Z0MYq7V43cscgAmBEgtNTZ8=,tag:4CmQdoXrLarrp/wcEDP3nA==,type:str]
 mbta:
-    apiKey: ENC[AES256_GCM,data:9gYRdpwmu6RzTkBfCY7m0uwc5h1itUbd3zZF70xlSQg=,iv:4WGoGzRUFwUSl3S5Q03ip4gMi/s3pKaIololB0+avGY=,tag:20/Ves7N5l9od2+R49Y6VA==,type:str]
+    apiKey: ENC[AES256_GCM,data:/pdknNEwYhr5v+kUKvslW8vzkw5uAEd5gae07DHgWIo=,iv:3dJfrLHhLkI+7rfUB2L+h46GevGyr7XPE3uwkfNAhuQ=,tag:mGEgRuX6WrGwI6/d0UrlHQ==,type:str]
 omni:
-    api_token: ENC[AES256_GCM,data:H4tHt5Na+hhnWNSin2L/fCOM1DVcLVRGEOoV7/PY0+/4Uq53ZYCTQJomfU6vAr/D9vOHqqeDsfcj2kC1XWyrF4s=,iv:HKVmjVGbdPpduVB2eRSgtTDpWqa72C9zWwXfWfQe9GI=,tag:CSOF8snh3mPhhDFfkidOVw==,type:str]
+    api_token: ENC[AES256_GCM,data:SEwCwthiRhjrd8Odnf8cb/VYq2i6dLZDMCcKPK9TyR1PCIAO1aDeNuKCrDRbRwl6bl2JI3j77OOoWzYdlKmitPg=,iv:0RxErEhGBx1rruKPZxvorijIEput8a4yDvG//oe42zs=,tag:FhbCa5xzyPUYPygP/4+0ug==,type:str]
 firecrawl:
-    api_key: ENC[AES256_GCM,data:I/AyN61NYOjiPW6qq7MIAPMCXhstNCEM55aEB+eAcjXDQxY=,iv:bFmLmJCXJ5CQJLTq6NO1/DqEFDrsfRKOsuSA87kZwNE=,tag:Yqga3AJ+IVJqOnqFPCXI9g==,type:str]
+    api_key: ENC[AES256_GCM,data:mBmW0xK+XrXSRtOeYs0nij4dWWvqRsNKb4MIxJhE+ymDkgE=,iv:QAlbyTqOBF+tFDd+pxpV3k8A1y+aLC6Cr53HPNrj90s=,tag:HQlhqICH0uuHWSPN7wuO/w==,type:str]
+atproto:
+    pds:
+        adminPassword: ENC[AES256_GCM,data:+oMMjXvCdZA2/cwJrT/dOxzpCwDiroNLhM9y8x5OEBE=,iv:tl5gAdQn7e6nL+KnExGxUsmWW74Dtfwb9YmlV1q1/kg=,tag:vWgzYOvTXZ5jAyRa9KVE9Q==,type:str]
 shortcut:
-    api_token: ENC[AES256_GCM,data:D0mgmgGH5DKFG7/oykbb747jQY4KWMo761eyTlD03Gh7IZdOaWxPvMiZAgXDG87fLnctbZrwCqHL5VYVQXUWsiSV+96qf7SAfHdfmJnsmtRCgjq+/j4qpoVXkDnZbE3Vuf1pirMMbLiJiQrJuxSBNgVsuq42vQLQqn96dwmoR4LTC1JYS4eOqrcc2xm4qmHFQWdX+ufXfKtDEcPIv40OVw==,iv:8NvbyVr5GA8O5YQl+HAv/cRHj/OARb4/Xrg4Hj5ZI+E=,tag:53IHCrYbyqkNvPasAprbZg==,type:str]
+    api_token: ENC[AES256_GCM,data:ztVsx+U6hAwORBfrSkqp0qjxBx6pqEfVtKoH8VRk+EWY7m1OjG6NI6I5uf39cb2aDizN4/4059XJ1BYEjKjtguKgvDY+naed5RPehSpdCc8sjUL4wUopboiq/siAPlHMVhcT7gQHQKmewWHCufjdyBjLp4W5e6J+4ow64qW0BnA5noGs55DXmQEdcsyqomg6o6j2buUQ+uWyfzHLkVK/AA==,iv:Refp9SUgKxTQxUAc8JOwXQGBRLBTUfu9Mc8Ipmu3eVs=,tag:rRKOzHDK/kmba5ftsFfyEg==,type:str]
 snowflake:
-    private_key: ENC[AES256_GCM,data:pZ2vpzNfqaC4Vl+l6N0oMEbwy7erNqhZpckFMsQ2ODlw8Md1J1ZjyQJZW4kjA5ZZpQPd1ZyYLZe+duJOhFUDvdV1/Z43kInJ2H7mBcervcDtJdFZeQHVv/bSsuU2JESDB+3EvtOTYCl5BS0ZtFTl9ge3RdxS4T+3QoXHkjZQ3UHD2iVyq+qVh2xUc3TNJpnJK1tn5A1MZk1BfHR+3w6xpWYxwIfFenFvtBSYXtWKVpM7PQJdlL6jF6uvtJqab7qcwqbTZmk+yITsNYCXnPrMFTOjpbiNlvCZPKj6o3x53j+Pi/0+DO5PxpeqDS+CFp0r24lRa56FN6viO/mxdSJS1EewmgWNGlMqWfXRVSjtkBvoo23Uotz5sRZcwsLtFRFOXkVq8mjWLUvuTOOPggJllKUSJyAcBq7myoKe1xsydC8EI36xlAQumKO2cXSJS7McR3gLOOkg79Wcjzws0vLNw2WIf1uSGB3HL5TL8y3MsDqXlwW02O7ihQff+11Zl/zEO4jB/aIukHsZxoZf48SjvxryvCqScCfFqt6GNfkbstJOYxfe2SYlunlRWKtTqqVFve7KntL3gwImEwE8rvsD2GlRZKPvQRcZ2o0In/mWeUPl5yXebfSk6pBWc9PJhXagAY+XwA2Cnu7vip3/zAzikQdwpadHS+KLm0124dVToMxZj3E/QXNLJMdD0nuIz/THrKm2ipFYXOSDF5wDD/s0Fo5iWu5y5WoQpOegIRfSB/xjm8biEPBW1vH0O4fMY05/iY0z9jXhrooB9N3FfC4JRX0etCuFhAY6o7iln7EvOmM8C8lcIIfSL/j+xgOvAmtsqhQCtXd5xInIxa1Uy9BbIMiaYo2g6jTk4k45uJRQyQDuqq85b77xDZxRT5CMG0KFY8a0XKC+vMtQiSKHM7hrkO5ZoME+1TFajA6lmsfWFIaKzSwZIuPhEeUHGThAJmIzO5i2m4Sfv5pK/oeQ0Mn0aZxDybClv1Uf36zCWAYIqz8SSBHYbFoQ14dVANYEBnOYJbD59buwMG6jTvaBKHIHeRnetjIAcCyMk/D4550pNoyKdLGplKcp7PBm484t87SUHH4lHp193TvKxr61rVKWQ4QpyrVNovLN/ix+8pPQuK3ocH50JASy4T7Vskcyy+tDFV8QtdX10aPo8B/yBER+thhoqxw/YcUi2ivTM5LaHDHNATSu1utKXkcEKFcItCVwPWITe2Q0yJwahVXaUvFXaaNdAC+7CPWyjrYeEZzroQQR2fMK1F4OEKX+e9TZqJYweENE5cmEcHtn5i4bvkwpZyZp3lEAgRzPVK6m8PUc1OAaSsJH4Hjaik5a99WChsaAUxYhcnUOQhYlCotsE29yPTUvZTcneRUc2ZVNnU1VzfNrFpK7Da7QYnJgc7oj+/6845ZrgSpVD2gZzOBAmos7EoPUOtDr0tAhbWg+GZKeiJK7rDxxJyzt270RsRsrkD6tCmclXAcGkS+tf6+mhh3uLgf+qyfnZEmAEZkcePTrn3jFroxsYga9I/+mwRw9Vr/Dm/jdXHHgu+NWbzKtwtTKeG3tpqMPik4sAGFsR06ZnTSAw4n0HEd5Nb77H0q2262fOpSHu9yJCTjU1CCXH9O214yJeIBAcbIasB7t3fgf89V72EsPTXPwJlxMyjWx1iLm5oXWjNsYSl4i8o4fsExJr/ypPrrM3Id/wYm6jexlxapmLNTkBOWCjnoez9ZaealJFjdibPWsbu0zcJ3iN1905LKevKrOkaqWiwS8nkS8kzft7AJzKf2x6HGRFPC6J4S5hn5kFAtYosc42dleEClO3kC91hiRdTG0VTzlAtgLza4Lqocw5C7suvkmmmcAD+R5ED6euaPjw9ep3fKwlYYOGhZjZ46M905Ydormw+uPsPo6s/NswzK3tl4iK6yR8xNIBA9TdJFtSTYqYhyfxBK836mxhTaYTsXmCgPnRgFEhUtgYHHNiuJmCEgfZ2IRoxnip8Yz1Bvq25v1g07oS/QHHnBbUtljeAAo6M/SRy3mZSpu91GVuhkRW6pa7YsjDtJLzjv9a8/quFhSwHBd1C1nZPqc9XnfQHeHYzKCr5HTT8FwH+fZj+4qU3jB/rlw/+JYHxMAi8QlLxhjSRTGsD00G7CPWVVMCKCIbLy1N8ZyGkH1fri3iTy6MLmFDlXMhrmWzuyMmaT2RJWSwElr6Y0XWXQ2kFXQvlBcUbvflgAtscy9Si4ZoIRKiQJhn3I8VPK4lF4aqAtliX6Fwcm8MbMM7PNq7dqYabxP3M1kbN7IB2q3UK5G51r7cmknBgda3JB+JOp0PjzpMqtJxcSYd0oF8lmid6eHyifI6+3WzaXpRv5SZK4jBDMhO5pPheAAf893655NtKNdbzUJwWKvzxaugEwfxiZUwWjIyUOULaHXDcXF7N6VcQM6xD7gKlawIp/v0q3TzqBws1Prqw1kXrhfkBnM+39Rdn5cVnXowWirvF0cUX/zLXQ6SJdu7C8Bxq4YFL2Nidj0ZwMWd2V6LYmV7K/RBJs=,iv:YkGUVpn/UWZk5U5mmA/lBZ9IGCDuD3YnxDVpZX5vyoY=,tag:31QaR0ffwGXt+AZI2p5U1A==,type:str]
+    private_key: ENC[AES256_GCM,data:Qaeqaj7dDuMrVJE7LqYwbrQr+mW+KEexx4KJhT/I0Z/8AXKtmCDXMUg4CzgBKn60X5SBHjGfJvcvti+B6X+KB16WQ1lk0K1fk+frs4PhteD10sOm6CAJRdO5/MUOKVRRQ2Z6Z/QN3yCXKEWxeP3RldQjf7JmXO2ZMc/nCm7IJ+nRWM2oo8iyCmXOQuCiIvkPCM39o8FjsfbBOW6v9/hOtjbcO+x16fEQTyOyrtHM4b/xOVcrioxbVNny1P7Y2cpAj2njuKCsBm+la7PrOZvhG2CMJq14+I3upeJXdomynsn9cf+QInZr1BHLXdFAzk1CJoUZIRVQ1zVdyz+YqZXCu76iC5cKKUaoEDbjU4MT4CxWo85zHmOJ/8Xbyiyg7g8HKuG7Z6VuB0xUEXsen7k7iN3tX9IxkSQ3+V6VGyBJB7CSIRcCdmgpMv+FiNgnP9jRc9sNLB8gmqY2yowma2LjKF8byaEtC68J+M6uliYsPa7ScAbdhuhM/QW5ZxhwosgD6VvL+enCgd71rhqEqavYCoI5NMZkE29+sqffiAb+h+hYhAQNyP6eamlxkfaVJ3CUvP0N+RqAva+zbMqt3ortdgEIwh1N5A3gRN7LaklX1X7/cACtxHU2ZnuWydFnvZEZs7mjy62LKLw8MiiEG70S9AhOkXr7D+ebsZJeYVazmadW/A10kA56m2Xzt0tmnrmSClW1N+ubW1soLptUqViTjMTpfH7rxs7dKz3U+wqnzIUq0l8JnOjGUHV2mxY6xy0qrgrS63XEYH2EsY5nc3T3pnXyRkEJN5DOpiKjV/fcVpawcdVUj5cYT9Mo0fnr8PokBwEu+LKZM2eEBu4S16RV4gSk+SOuDsSutmUKL9o3uPzgbC8OxcZA/FxiZh4YBTkGz2HYc+MkmDkw9MWlFks0b+cK+6lt4bGTvxjhijdG9+mEPzdd+fH14LcR6fa+vFB+OWhnmx4G0pGMAbrFd1w3x12DDPcQHHyPwwPPdIHcjURAyL0gzbXogSkNipBjjFXha9Xu8V/WOJ4uLdRKK6cM5uC3cNRw1a+0U33zBM0DVGzURjZrOkPFM7FgDYpm1RgkJBrYPVNUvr531f9k31RGLa0LSd3q1NiWI05yzat0DhN83nebr6kN60H8cP3CSZhPgFPbxwm+xPreASkEnJX6Hszx1WOBzJHN70/LXccgHdI8pwV+ronAKDSfrCYd3YBXBMGFI/wxp1wJFxcQZpqb0jiBWZ/bXcKP7SZQeobxHMAhaz4rKSQMo9O7iWQ3AH/gnx4XvdmxpO4Uo5v7ycKHPSI5vG4zKIEUDSRKP7iHJ4p11tc9LLPlnNj9up36DqelCZ3nSyq+Ubvuv7ZchlAkwzbCA77wEyuvEGYl9/N7YeLUdhyiMxZm1ZQvTpxSy88dEqRV6GP0mE9gz1Hkh1clpBCrwy/lxx3ZnKYkBX/70bZxYKUlp6jfD0X0dFOTtp/vevgcflwLXU4VnR+uY6poszekP2iJ6etmX9lmH30j8N1g5NLQEZdCnTsHSfK/0eUgaEjmjb51tnx7aaN08zgT/sg2AYohdBFpKkEx7sF50EkeAZbjNbmPlHc5YehOlk0guGjK5dqpk6WARuK+sFhd/aF2Y7SD98aC6xJoAs5Z8+wslT8vDcG24jklxYmxMQMX+ld0h4Fgt8INMaTqgNQsmhfGiIRLiWzQtD/ETL3ZgtNTU4QtrYtrCu7vXyVVDmjImderNpiwAOWAMAiGSofRSgVvs2/xMjo83BrCjBDPQqVV8VdAILwPj/ZxJym4EKFwH5FxDS/Nb60awpWqAm3fk5K5A28LyjjKFR8t3vxi1VlNvyfOXeH5btlkE4e12gRVzAEbn5dGDeNsgvZi7WA2tHMUI3tUGSTniF+zFDo6+jiPxLm1At8BYd6J9E7G9kzbht94ON5H7wLj0WeAaFwTeo7f4/q69BXoYe5Xq+wRkFEErZ2iPVcglZoWO4hms9oxl2dbtnfImawW+6DMUVnQ5VeF7LI680vbMMZjNnCVsOUucAcQt8vxrvpHYT/1LqoTi9a9kOAiJSTE8zUIWPGhoQe/bxZrhyBo+Zda1Toq5MoLLpe9QsTUc6/ztdVx6O41HotS5NxZuUy8oF6DW/HPqrkfOgv+3WeShF8yDSnWnCpf6F6M15LdGFgjJiaajvah6XDIJ83H3UmnETLjy8syZ1sxULaORA4/sERpBr4ZZJSfYhCsxlWhOZ+Pf+0LYIDOy4KmY90nCImLe37+z1uob6FIU71GZlO4UW5yywxfJHESz6LXq5EvVghomT8eztF1kMfWWfbKLFFaJC72KOoZC9RW5kw/vvYNGlK36EuKLRTflIuSj+csEOuFalbdKjfyS+ZHgs2tviLTeFVlwcdXmDD42GbVZGlg0qP5nuOoKY9ME1KOOdy94du+egX1bJezEwvpQj7KI1GXaa0YAta2b2vWvbIc1gYLoATWmXk5XH7XJOHe6eZtJtVNSw+uKAs7Gxvn0dZAGWkC9N+AsCexOxIVOZ4=,iv:nTnYyHNq3zoR+mlCHfF4UbwJtgnfRRwjX7YLHA+FxUs=,tag:N43O7cyygK4nkt0ApvOarA==,type:str]
 sops:
-    lastmodified: "2026-05-08T12:59:21Z"
-    mac: ENC[AES256_GCM,data:hYysRWY2ge8SWm819QdTbUWNgNN7x1R8We8yp+5FZi2H2VyzwLhCngwXuiDsrd08IgG1vGxlMSYSwBnp9pskB47zIfd3Vhie4OqZK4UY7MDyUfeNCSI7Q5M1F7MLaUbUHA01mHOdCREesIe2a3uqGlOSRbByz6y20VfTclSCNoM=,iv:j7LZlS9g8V2SVfFwdBPIJcQ9yQYzuD+DGICIeUAaxGU=,tag:5qZ7i2I1w9WudUtKu4IRXg==,type:str]
+    lastmodified: "2026-05-30T22:10:16Z"
+    mac: ENC[AES256_GCM,data:FGbcCyRidC62dGW5W7lZHkSXFaA2KJ63Z8FtCHlN5fymantsDJoqhoBGNvgeuO82++Q6cpB8TxzmWIVBRiJzP63V4xj2hQSldmDidOp9jMa7hhVYGW4aAj9AQstgSZ6k8EGcl4qXr54hNx1xfAGdHP7w9++d918RpTFOcpUnqN4=,iv:C32oDudwsKRLJnfEV5AhHJbtvWZUCsD+121vFAGXkGk=,tag:N0X8qIkU5IuFHQeu+ZatKw==,type:str]
     pgp:
-        - created_at: "2026-05-08T12:59:21Z"
+        - created_at: "2026-05-30T22:10:16Z"
           enc: |-
             -----BEGIN PGP MESSAGE-----
 
-            hF4DYhYgzaKQYR0SAQdAr0P4+cwzyNKrnikUEt7Z0P78V+LvQQb89YP+5PbgUXww
-            G0fBIHD2l9WsgONVsse2wc0zB1qP7uwIIlSBuy+GDJIqgQm9mMHtxMKe5wbPCXt9
-            1GgBCQIQEW6xLuaMWq9rJ1Ncff9Hhq5GLQxl6GWI3sl8aVEle05jelXbMfwDUZW+
-            x4ua16OtNoZ1dqortN1uV30wGdVaDPQn8TNbxcHkSCoA9g5F4qec9SvaSRuRtNrr
-            X0+gsawBTNWmsw==
-            =l/MZ
+            hF4DYhYgzaKQYR0SAQdAjifE75qu3SnOiwKRhKBaOKp0JTYPc6fj0zELLi5clV0w
+            6YJp6p65e/hC0SlnmKGMjtKFq7l9BMBjbMPqq0L/4A8VQLdwliWP4TIrK5VcByTW
+            1GYBCQIQBhSxh+uGgSOAsOPpAWn++0nB6mH84aDwT3S1Qru6m1D7TC1nkhDlnYPm
+            jhSJek+5SVPjxSSstDk7FWZWqKKYoidrQFHWAQ2C7gdtsxAU4uG1yQYiXLhklFKy
+            lILIRKT9izk=
+            =02FH
             -----END PGP MESSAGE-----
           fp: 905EBD494A6AA2B774ED5C67621620CDA290611D!
-        - created_at: "2026-05-08T12:59:21Z"
+        - created_at: "2026-05-30T22:10:16Z"
           enc: |-
             -----BEGIN PGP MESSAGE-----
 
-            hF4DiMEcS0DKCgcSAQdAW4XrT9aZ9Xc6MPXoWORLjmrMa/sW1shqbUwIjzt1bW8w
-            EQfo5Q7HtEjt2j4A7mIyfp7byXMJy51IIONhx5+tPvfhvGeEsK4yTzsSimuXCDNn
-            1GgBCQIQnqSIXE9T6bRgMHCR8oVB//rZJcY2FdbQbo3o3Yk/KusQGZ0DtsqCcTD4
-            oOofwfyO3eSzwEQmj0RlQbcXw+atAy02UE/3UbD9uAPuOh2Ml9qZm1CEGK8N58yq
-            qfMbAZ1wTJmZqA==
-            =B4FU
+            hF4DiMEcS0DKCgcSAQdAL9NaKjailDVtiL0X0EWax/4dfe7Dh1yB1M4+1N7cxCEw
+            cFFCFwM+IPbOddoAFxXJ9eM9I5Hy+dYLNGDH4E/izaw3cRQQ0i4fOdCtMU8Kr/Cu
+            1GYBCQIQcTLSxLutSHmCgsGNnfCSXdFnBeRGwgv+Bs0RO1AUmsCH35mQx+QsXt0r
+            jPpW1IVpaO3KqdotCMhqq/g9/ApbM0WvFtjKMuVfurridNNob5nkoOiyEW/lpGRQ
+            KWrZOFS5Xr8=
+            =nsk3
             -----END PGP MESSAGE-----
           fp: 29451B3218DDD551B34905DF88C11C4B40CA0A07!
-        - created_at: "2026-05-08T12:59:21Z"
+        - created_at: "2026-05-30T22:10:16Z"
           enc: |-
             -----BEGIN PGP MESSAGE-----
 
-            hF4DSKZOgzO4L1ASAQdATYyavPsY7arVoSMGtCX9/4TwFq5ivhzcH+pGLcd5kisw
-            a+2INDIyQorGbmSFB+/EVZHklvXtZ+QRfH564OAkOajVV+85X7Mi/7XLxohb4Vps
-            1GgBCQIQGidCl0aj0/NAl1vCjKGPjr0cIBiDJy8+ZfGHLsFAuLVykOvV1v91BpnI
-            LK+t+uP6QhVTNCPlqHGooa0wfg0nFJAFC62jALI6dyNXlOXC/RXzzahtu7BFtXJp
-            gCjoVmfbdo4TeA==
-            =7wj7
+            hF4DSKZOgzO4L1ASAQdA3tq5V4fUMektLVNtsXJISEC3bEzvOgtMfpj2bhMjzj4w
+            2//AzpITvLgxHQ+NUeTkujbYoPG2ZsVPtatCHm5OJpSIjJe+8icj4asOcWODvt7m
+            1GYBCQIQ5tlhYojbChW9Tg9mnwt5IcMA7ZCJPn4IDKkXCYcIgcNOGlOJTSPgLCkJ
+            o/QGJgAGhEMijHwr6iut+cT1TkZBfysbmduBbt7tQymrB0mMfVxce3ifAADyKXXf
+            ZNPimYMcXgw=
+            =O/7w
             -----END PGP MESSAGE-----
           fp: A2164C4257BB2EBFA51F26E948A64E8333B82F50!
     unencrypted_suffix: _unencrypted

--- a/overlays/default.nix
+++ b/overlays/default.nix
@@ -8,12 +8,12 @@
   # https://nixos.wiki/wiki/Overlays
   modifications = final: prev: {
     go1_26 = prev.go.overrideAttrs (oldAttrs: let
-      newVersion = "1.26.1";
+      newVersion = "1.26.3";
       in {
         version = newVersion;
         src = prev.fetchzip {
           url = "https://go.dev/dl/go${newVersion}.src.tar.gz";
-          hash = "sha256-639cg0AQx1yKpkJtMI6/34miHPkKHHBfZV1yz3zWp2Y=";
+          hash = "sha256-f+sGifVA+laOZWNcTX9lz2oKaFzh1iqYCcQipb0FjDo=";
         };
         patches = [];
         GOROOT_BOOTSTRAP = "${prev.go}/share/go";


### PR DESCRIPTION
TL;DR
-----

Adds an atproto home module for managing a personal PDS, refreshes development
tooling (railway CLI, Go 1.26.3), and cleans up macOS app management by
removing unused tools and switching Teams to homebrew.

Details
-------

Adds `home/modules/atproto` to provide the atproto-goat CLI (from unstable),
configure `PDS_HOST`, and expose `PDS_ADMIN_PASSWORD` via sops for both zsh
and fish shells. The module is wired into the full workstation profile and the
corresponding secret is added to `secrets.yaml`.

Adds `railway` to the development module's package list for Railway.app CLI
access. Updates the Go overlay from 1.26.1 to 1.26.3 with the correct source
hash.

Cleans up macOS app management: switches Teams from the nix-managed package in
the replicated module to the homebrew `microsoft-teams` cask (which tracks
updates more reliably), and removes `codelayer`, `macwhisper`,
`notion-calendar`, and `snowflake-snowsql` casks along with the
`humanlayer/humanlayer` tap that are no longer in use.