### PR TITLE
Upgrade to nixpkgs 26.05

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -8,11 +8,11 @@
         "systems": "systems"
       },
       "locked": {
-        "lastModified": 1779491364,
-        "narHash": "sha256-I7HiyUp+omP7yg2NVENpwytmWtoQKzkSmumRmxSNKhE=",
+        "lastModified": 1779899208,
+        "narHash": "sha256-2LN9997pFL+b1FWA0375mm6/THvIq7okQy+Mc49/Uq0=",
         "owner": "1Password",
         "repo": "shell-plugins",
-        "rev": "35ab17ebbf12824793596d3a6525e6d165246635",
+        "rev": "17d290441359204fc6df8de252698f52cbd87047",
         "type": "github"
       },
       "original": {
@@ -28,16 +28,16 @@
         ]
       },
       "locked": {
-        "lastModified": 1772129556,
-        "narHash": "sha256-Utk0zd8STPsUJPyjabhzPc5BpPodLTXrwkpXBHYnpeg=",
-        "owner": "lnl7",
+        "lastModified": 1779036909,
+        "narHash": "sha256-zXcwYQGCT6pzinK+1dBB2ekTVtfxGZAapb3Evdcu4fY=",
+        "owner": "nix-darwin",
         "repo": "nix-darwin",
-        "rev": "ebec37af18215214173c98cf6356d0aca24a2585",
+        "rev": "56c666e108467d87d13508936aade6d567f2a501",
         "type": "github"
       },
       "original": {
-        "owner": "lnl7",
-        "ref": "nix-darwin-25.11",
+        "owner": "nix-darwin",
+        "ref": "nix-darwin-26.05",
         "repo": "nix-darwin",
         "type": "github"
       }
@@ -49,43 +49,43 @@
         ]
       },
       "locked": {
-        "lastModified": 1779506708,
-        "narHash": "sha256-QOD/CNm196nCJRheux/URi4/HE66fthdOMqCJoPP1Y0=",
+        "lastModified": 1780361225,
+        "narHash": "sha256-wnV9ttf4fPWNonBIQmvlrSlNpQYgx5HgWWd007mwIFA=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "3ee51fbdac8c8bdfe1e7e1fcaba6520a563f394f",
+        "rev": "e28654b71096e08c019d4861ca26acb646f583d8",
         "type": "github"
       },
       "original": {
         "owner": "nix-community",
-        "ref": "release-25.11",
+        "ref": "release-26.05",
         "repo": "home-manager",
         "type": "github"
       }
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1779495359,
-        "narHash": "sha256-KZ/9A3gvlKboDm2Kbv4A6KnfA9wMSfebyoEU91HeBn8=",
+        "lastModified": 1780383649,
+        "narHash": "sha256-FS3od1iIyWYz68tqZGGc92Po7Ji+G2NEm6+a4s4RI0w=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "2b76bb8a3c79707f0d0903e486da6d9851654c3c",
+        "rev": "595ee2b1a31a50efcb8db3824999abb98ec1d0c9",
         "type": "github"
       },
       "original": {
         "owner": "nixos",
-        "ref": "nixpkgs-25.11-darwin",
+        "ref": "nixpkgs-26.05-darwin",
         "repo": "nixpkgs",
         "type": "github"
       }
     },
     "nixpkgs-unstable": {
       "locked": {
-        "lastModified": 1779475168,
-        "narHash": "sha256-gm3D4FF9EcZlXK/ZnsC6IYzpEQplOoT+LPTurzOPyrk=",
+        "lastModified": 1780336545,
+        "narHash": "sha256-vhVhuXzFrIOfcssC/9hDHx7MHzDKjF3keHuREOQqQiQ=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "a0991c886dc83e6e9de01d5266e4842985b1850e",
+        "rev": "4df1b885d76a54e1aa1a318f8d16fd6005b6401f",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -2,14 +2,14 @@
   description = "crdant's system configration ";
 
   inputs = {
-    nixpkgs.url = "github:nixos/nixpkgs/nixpkgs-25.11-darwin";
+    nixpkgs.url = "github:nixos/nixpkgs/nixpkgs-26.05-darwin";
     nixpkgs-unstable.url = "github:nixos/nixpkgs/nixpkgs-unstable";
     sops-nix.url = "github:Mic92/sops-nix";
 
-    home-manager.url = "github:nix-community/home-manager/release-25.11";
+    home-manager.url = "github:nix-community/home-manager/release-26.05";
     home-manager.inputs.nixpkgs.follows = "nixpkgs";
 
-    darwin.url = "github:lnl7/nix-darwin/nix-darwin-25.11";
+    darwin.url = "github:nix-darwin/nix-darwin/nix-darwin-26.05";
     darwin.inputs.nixpkgs.follows = "nixpkgs"; # ...
 
     _1password-shell-plugins.url = "github:1Password/shell-plugins";

--- a/home/modules/base/default.nix
+++ b/home/modules/base/default.nix
@@ -65,7 +65,7 @@ in {
 
     # Basic packages for all environments
     packages = with pkgs; [
-      dogdns
+      doggo
       fd
       moreutils
       nmap
@@ -286,12 +286,15 @@ in {
       enable = true;
       viAlias = true;
       vimAlias = true;
+      withRuby = false;
+      withPython3 = false;
       
       # Core plugins used everywhere
       plugins = with pkgs.vimPlugins; [
         editorconfig-nvim
         {
           plugin = rose-pine;
+          type = "viml";
           config = ''
             let g:rose_pine_dark_variant = 'moon'
             let g:rose_pine_disable_background = 1 
@@ -307,7 +310,7 @@ in {
       ];
       
       # Core Lua config (basic settings, keymaps, etc.)
-      extraLuaConfig = ''
+      initLua = ''
         -- General
         vim.opt.encoding = "utf-8"          -- The encoding displayed
         vim.opt.fileencoding = "utf-8"      -- The encoding written to file

--- a/home/modules/base/zsh.nix
+++ b/home/modules/base/zsh.nix
@@ -7,6 +7,7 @@ in {
   programs.zsh = {
     enable = true;
     enableCompletion = true;
+    dotDir = config.home.homeDirectory;
 
     oh-my-zsh = {
       enable = true;

--- a/home/modules/claude/default.nix
+++ b/home/modules/claude/default.nix
@@ -139,7 +139,7 @@ in {
           claude-code-nvim
         ];
 
-        extraLuaConfig = lib.mkAfter ''
+        initLua = lib.mkAfter ''
           -- Claude code integration
           require('claude-code').setup({})
         '';

--- a/home/modules/desktop/default.nix
+++ b/home/modules/desktop/default.nix
@@ -61,7 +61,7 @@ in {
     # Core Neovim configuration
     neovim = {
       # Core Lua config (basic settings, keymaps, etc.)
-      extraLuaConfig = ''
+      initLua = ''
         -- Appearance
         if vim.fn.has('gui_running') == 1 then
           vim.opt.background = "light"
@@ -110,14 +110,14 @@ in {
 
       # Third-party applications (in /Applications/)
       ${pkgs.dockutil}/bin/dockutil --add "/Applications/Ghostty.app" --no-restart
-      ${pkgs.dockutil}/bin/dockutil --add "/Applications/Arc.app" --no-restart
+      ${pkgs.dockutil}/bin/dockutil --add "/Applications/Dia.app" --no-restart
       ${pkgs.dockutil}/bin/dockutil --add "${pkgs.slack}/Applications/Slack.app" --no-restart
       ${pkgs.dockutil}/bin/dockutil --add "/Applications/Superhuman.app" --no-restart
       ${pkgs.dockutil}/bin/dockutil --add "${pkgs.zoom-us}/Applications/zoom.us.app" --no-restart
 
       # System applications
       ${pkgs.dockutil}/bin/dockutil --add "/System/Applications/Messages.app" --no-restart
-      ${pkgs.dockutil}/bin/dockutil --add "/Applications/Beeper Pro.app" --no-restart
+      ${pkgs.dockutil}/bin/dockutil --add "/Applications/Beeper Desktop.app" --no-restart
       ${pkgs.dockutil}/bin/dockutil --add "/System/Applications/Contacts.app" --no-restart
 
       # Productivity apps

--- a/home/modules/desktop/vimr-wrapper.nix
+++ b/home/modules/desktop/vimr-wrapper.nix
@@ -2,7 +2,7 @@
 
 let
   vimrCommand = "${pkgs.vimr}/Applications/VimR.app/Contents/Resources/vimr" ;
-  wrapperArgs = config.programs.neovim.finalPackage.wrapperArgs  ;
+  wrapperArgs = lib.escapeShellArgs config.programs.neovim.finalPackage.wrapperArgs;
   neovimArgs = ''
     --add-flags '--nvim' --add-flags '--cmd "set packpath^=${vimUtils.packDir config.programs.neovim.finalPackage.packpathDirs}"' \
     --add-flags '--cmd "set rtp^=${vimUtils.packDir config.programs.neovim.finalPackage.packpathDirs}"';
@@ -13,7 +13,7 @@ in stdenv.mkDerivation {
 
   dontUnpack = true ;
   dontPatch  = true ;
-  dontConfigure = true ;  
+  dontConfigure = true ;
   dontBuild = true ;
 
   nativeBuildInputs = [ makeWrapper ];

--- a/home/modules/editor/default.nix
+++ b/home/modules/editor/default.nix
@@ -21,6 +21,7 @@ in {
         diffview-nvim
         {
           plugin = fzf-vim;
+          type = "viml";
           config = ''
             " Initialize configuration dictionary
             let g:fzf_vim = {}
@@ -40,7 +41,7 @@ in {
         vim-commentary
       ];
 
-      extraLuaConfig = ''
+      initLua = ''
         -- Core editor settings
         require('snacks').setup({})
 

--- a/home/modules/go/default.nix
+++ b/home/modules/go/default.nix
@@ -21,7 +21,7 @@ in {
     
     # Go-specific Neovim configuration
     neovim = {
-      extraLuaConfig = lib.mkAfter ''
+      initLua = lib.mkAfter ''
         -- Go language server
         require('gopls')
         

--- a/home/modules/infrastructure/default.nix
+++ b/home/modules/infrastructure/default.nix
@@ -16,14 +16,13 @@ in {
       terraform
       terraform-lsp
       vault
-      wrangler
     ];
   };
   
   programs = {
     # Terraform-specific Neovim configuration
     neovim = {
-      extraLuaConfig = lib.mkAfter ''
+      initLua = lib.mkAfter ''
         -- Terraform language server
         require('terraform_lsp')
       '';

--- a/home/modules/javascript/default.nix
+++ b/home/modules/javascript/default.nix
@@ -14,7 +14,7 @@ in {
   programs = {
     # JavaScript/TypeScript-specific Neovim configuration
     neovim = {
-      extraLuaConfig = lib.mkAfter ''
+      initLua = lib.mkAfter ''
         -- TypeScript language server
         require('ts_ls')
       '';

--- a/home/modules/python/default.nix
+++ b/home/modules/python/default.nix
@@ -14,7 +14,7 @@ in {
   programs = {
     # Python-specific Neovim configuration
     neovim = {
-      extraLuaConfig = lib.mkAfter ''
+      initLua = lib.mkAfter ''
         -- Python language server
         require('pyright')
       '';

--- a/home/modules/rust/default.nix
+++ b/home/modules/rust/default.nix
@@ -16,7 +16,7 @@ in {
   programs = {
     # Rust-specific Neovim configuration
     neovim = {
-      extraLuaConfig = lib.mkAfter ''
+      initLua = lib.mkAfter ''
         -- Rust language server
         require('rust_analyzer')
       '';

--- a/home/modules/security/default.nix
+++ b/home/modules/security/default.nix
@@ -52,7 +52,7 @@ in {
         nvim-sops 
       ];
 
-      extraLuaConfig = ''
+      initLua = ''
         vim.keymap.set('n', '<leader>ef', vim.cmd.SopsEncrypt, { desc = '[E]ncrypt [F]ile' })
         vim.keymap.set('n', '<leader>df', vim.cmd.SopsDecrypt, { desc = '[D]ecrypt [F]ile' })
       '';

--- a/home/modules/swift/default.nix
+++ b/home/modules/swift/default.nix
@@ -24,7 +24,7 @@ in {
         # xcodebuild-nvim 
       ];
 
-      extraLuaConfig = lib.mkAfter ''
+      initLua = lib.mkAfter ''
         -- Swift language server
         require('sourcekit')
       '';

--- a/overlays/default.nix
+++ b/overlays/default.nix
@@ -16,7 +16,9 @@
           hash = "sha256-f+sGifVA+laOZWNcTX9lz2oKaFzh1iqYCcQipb0FjDo=";
         };
         patches = [];
-        GOROOT_BOOTSTRAP = "${prev.go}/share/go";
+        env = (oldAttrs.env or {}) // {
+          GOROOT_BOOTSTRAP = "${prev.go}/share/go";
+        };
       }
     );
 
@@ -37,6 +39,33 @@
     fish = final.unstable.fish;
 
     mas = final.unstable.mas;
+
+    bartender = prev.bartender.overrideAttrs (_oldAttrs: {
+      version = "6.5.2";
+
+      src = prev.fetchurl {
+        url = "https://downloads.macbartender.com/B2/updates/B6Latest/Bartender%206.dmg";
+        hash = "sha256-FVBgOJJYtabYXIUcbZgtsqJe5syV1HRcDfbZ8UkbJIQ=";
+      };
+
+      # undmg doesn't support APFS DMGs; use hdiutil directly instead
+      unpackCmd = ''
+        mnt=$(TMPDIR=/tmp mktemp -d -t nix-XXXXXXXXXX)
+        function finish { /usr/bin/hdiutil detach "$mnt" -force; rm -rf "$mnt"; }
+        trap finish EXIT
+        /usr/bin/hdiutil attach -nobrowse -mountpoint "$mnt" "$curSrc"
+        cp -a "$mnt/Bartender 6.app" "$PWD/"
+      '';
+
+      sourceRoot = ".";
+
+      installPhase = ''
+        runHook preInstall
+        mkdir -p "$out/Applications"
+        cp -r "Bartender 6.app" "$out/Applications/"
+        runHook postInstall
+      '';
+    });
 
     container = prev.container.overrideAttrs (oldAttrs: rec {
       version = "0.10.0";

--- a/pkgs/claude-code-transcripts/default.nix
+++ b/pkgs/claude-code-transcripts/default.nix
@@ -13,6 +13,11 @@ python3.pkgs.buildPythonPackage rec {
     python3.pkgs.uv-build
   ];
 
+  postPatch = ''
+    substituteInPlace pyproject.toml \
+      --replace-fail 'uv_build>=0.9.7,<0.10.0' 'uv_build>=0.9.7'
+  '';
+
   src = fetchFromGitHub {
     owner = "simonw";
     repo = "claude-code-transcripts";

--- a/systems/modules/base/default.nix
+++ b/systems/modules/base/default.nix
@@ -81,7 +81,7 @@ in {
   # bash is enabled by default
 
   environment = {
-    enableAllTerminfo = true;
+    # enableAllTerminfo = true;
 
     systemPackages = with pkgs; [
       coreutils

--- a/systems/modules/desktop/default.nix
+++ b/systems/modules/desktop/default.nix
@@ -14,6 +14,10 @@ let
         upgrade = true;
       };
       
+      packages = [
+        "wrangler"
+      ];
+
       casks = [
         "displaybuddy"
         "font-cabin"
@@ -66,7 +70,7 @@ in (lib.mkMerge [
         slack
         zoom-us
       ] ++ lib.optionals isDarwin [
-        unstable.bartender
+        bartender
         duti
         grandperspective
         hexfiend


### PR DESCRIPTION
TL;DR
-----

Bumps all flake inputs to the 26.05 release channel and fixes every compatibility break that surfaced in `make host` and `make user`.

Details
-------

Updates `flake.nix` to track `nixpkgs-26.05-darwin`, `home-manager/release-26.05`, and `nix-darwin-26.05`, and regenerates `flake.lock`.

Adds a `bartender` overlay entry replacing the broken 6.4.1 zip (404) with 6.5.2's DMG. Uses `hdiutil` directly for unpacking since the DMG is APFS-formatted and `undmg` only handles HFS+. Switches `systems/modules/desktop` from `unstable.bartender` to `pkgs.bartender` so the overlay actually applies — `unstable.*` packages bypass the modifications overlay entirely. Fixes the Go overlay's `GOROOT_BOOTSTRAP` attribute, which had to move from a top-level derivation argument into the `env` attrset to match how nixpkgs 26.05's Go package sets it; the two definitions conflicted and broke any package using `buildGo1_26Module`.

Renames `programs.neovim.extraLuaConfig` to `initLua` across all eleven home modules that use it, following the home-manager 26.05 rename. Adds explicit `type = "viml"` to the `fzf-vim` and `rose-pine` plugin blocks whose configs are VimL. Sets `withRuby = false` and `withPython3 = false` in the base neovim config, adopting the new defaults since no installed plugin requires either provider. Locks `programs.zsh.dotDir` to the home directory to preserve the current `.zshrc` location and silence the stateVersion warning.

Fixes `vimr-wrapper.nix` where `finalPackage.wrapperArgs` changed from a string to a list; wraps it with `lib.escapeShellArgs` before interpolating into the `makeWrapper` call.

Patches `pkgs/claude-code-transcripts` to strip the `uv_build<0.10.0` upper bound from `pyproject.toml` at build time via `postPatch`; nixpkgs 26.05 ships `uv-build 0.10.0` which the package's build system rejected.

Moves `wrangler` from nix packages to `homebrew.packages`. The nixpkgs 26.05 wrangler build fails in the macOS sandbox due to a Node.js v22 file descriptor interaction in the `tsup` DTS bundler — and because the modifications overlay changes the nixpkgs instance hash, the package can't be substituted from cache.nixos.org and must be built locally.