### PR TITLE
Fix atuin migration mismatch and rose-pine v3 regression; add writing tools

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -81,11 +81,11 @@
     },
     "nixpkgs-unstable": {
       "locked": {
-        "lastModified": 1779475168,
-        "narHash": "sha256-gm3D4FF9EcZlXK/ZnsC6IYzpEQplOoT+LPTurzOPyrk=",
+        "lastModified": 1781268102,
+        "narHash": "sha256-Zn5KTggEmUB3lXn/ccERNcBdddE6IaOFber9dWViWDg=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "a0991c886dc83e6e9de01d5266e4842985b1850e",
+        "rev": "49a4bd0573c376468dd7996ddb6f9fa31d8c4d97",
         "type": "github"
       },
       "original": {

--- a/home/modules/base/default.nix
+++ b/home/modules/base/default.nix
@@ -144,6 +144,7 @@ in {
     
     atuin = {
       enable = true;
+      package = pkgs.unstable.atuin;
       enableZshIntegration = true;
       enableBashIntegration = true;
       enableFishIntegration = true;
@@ -292,10 +293,15 @@ in {
         editorconfig-nvim
         {
           plugin = rose-pine;
+          type = "lua";
           config = ''
-            let g:rose_pine_dark_variant = 'moon'
-            let g:rose_pine_disable_background = 1 
-            colorscheme rose-pine
+            require('rose-pine').setup({
+              variant = 'moon',
+              styles = {
+                transparency = true,
+              },
+            })
+            vim.cmd('colorscheme rose-pine')
           '';
         }
         vim-surround

--- a/home/modules/claude/default.nix
+++ b/home/modules/claude/default.nix
@@ -12,6 +12,7 @@ let
     "last30days-skill" = "mvanhorn/last30days-skill";
     "replicatedhq" = "replicatedhq/replicated-claude-marketplace";
     "shortrib-labs" = "shortrib-labs/shortrib-claude-marketplace";
+    "draft-review-kit-local" = "EveryInc/draft-review-kit";
   };
 in {
   # Custom option for Claude Code plugin management.

--- a/home/modules/writing/default.nix
+++ b/home/modules/writing/default.nix
@@ -2,7 +2,13 @@
 
 {
   home.packages = with pkgs; [
+    pandoc
     readwise-cli
     spiral-cli
+    texlive.combined.scheme-small
+  ];
+
+  programs.claude.plugins = [
+    "draft-review-kit@draft-review-kit-local"
   ];
 }


### PR DESCRIPTION
TL;DR
-----
Fixes two regressions introduced by a database/package version skew — an
atuin migration error on every shell invocation and a rose-pine colorscheme
crash at Neovim startup — and adds the draft-review-kit Claude plugin with
document conversion tooling to the writing module.

Fixes
-----
**Atuin migration mismatch.** The atuin database had migration
`20260224000100` applied (by a transiently-run 18.16.1 binary) but the
stable nixpkgs package was 18.10.0, which doesn't know about it. This
caused the error `migration 20260224000100 was previously applied but is
missing in the resolved migrations` on every shell line. Fixed by pinning
atuin to `pkgs.unstable.atuin` and bumping nixpkgs-unstable to pick up
18.16.1, which knows about the migration.

**rose-pine Neovim startup crash.** rose-pine v3 dropped all Vimscript
colorscheme files. The plugin config was still using the old Vimscript API
(`g:rose_pine_dark_variant`, `g:rose_pine_disable_background`,
`colorscheme rose-pine` as viml). Switched to `type = "lua"` with the v3
Lua setup API — `variant = 'moon'` and `styles = { transparency = true }`.

Additions
---------
- `draft-review-kit@draft-review-kit-local` Claude plugin added to the
  writing module via `programs.claude.plugins`; its marketplace
  (`EveryInc/draft-review-kit`) registered in the claude module under the
  key `draft-review-kit-local`
- `pandoc` and `texlive.combined.scheme-small` added to writing module
  packages for document conversion and typesetting
