### PR TITLE
Dedupe crdant.keys authorized-keys fetch

### DIFF
--- a/home/users/crdant/authorized-keys.nix
+++ b/home/users/crdant/authorized-keys.nix
@@ -1,0 +1,7 @@
+let
+  authorizedKeysFile = builtins.fetchurl {
+    url = "https://github.com/crdant.keys";
+    sha256 = "sha256-hUjgwUIe/R8RxRgk7kT+wOFr6erF+fI6mQS1+3uRhe0=";
+  };
+in
+  builtins.filter (entry: entry != [] && entry != "") (builtins.split "\n" (builtins.readFile authorizedKeysFile))

--- a/home/users/crdant/chuck.nix
+++ b/home/users/crdant/chuck.nix
@@ -3,15 +3,7 @@ let
   isDarwin = pkgs.stdenv.isDarwin ;
   isLinux = pkgs.stdenv.isLinux ;
 
-  authorizedKeysFile = builtins.fetchurl {
-    url = "https://github.com/crdant.keys";
-    sha256 = "sha256-ZsQD4lIGz/vWKvee26gTKhX6Qf4U7HeNvgHmGB0Qo2A=";
-  };
-
-  authorizedKeys = let
-      content = builtins.readFile authorizedKeysFile;
-    in
-      builtins.filter (entry: entry != [] && entry != "") (builtins.split "\n" content);
+  authorizedKeys = import ./authorized-keys.nix;
 in
 {
   # The user should already exist, but we need to set this up so Nix knows

--- a/home/users/crdant/crdant.nix
+++ b/home/users/crdant/crdant.nix
@@ -4,15 +4,7 @@ let
   isDarwin = pkgs.stdenv.isDarwin ;
   isLinux = pkgs.stdenv.isLinux ;
 
-  authorizedKeysFile = builtins.fetchurl {
-    url = "https://github.com/crdant.keys";
-    sha256 = "sha256-5pZdp4Hq0QfdOYgY4jFyf/EDc4hzJJOI6deJjxOfBJs=";
-  };
-
-  authorizedKeys = let
-      content = builtins.readFile authorizedKeysFile;
-    in
-      builtins.filter (entry: entry != [] && entry != "") (builtins.split "\n" content);
+  authorizedKeys = import ./authorized-keys.nix;
 in
 {
   # The user should already exist, but we need to set this up so Nix knows


### PR DESCRIPTION
TL;DR
-----

Both `crdant.nix` and `chuck.nix` fetched the same GitHub SSH public keys (`https://github.com/crdant.keys`) but pinned separate, drifted, stale hashes. This consolidates the fetch into one shared source and updates it
to the current hash.

Details
-------

Adds `home/users/crdant/authorized-keys.nix`, a plain expression that performs the fixed-output `builtins.fetchurl` once and evaluates to the parsed list of authorized-key strings. It carries the single correct `sha256` for the current contents of `https://github.com/crdant.keys`.

Replaces the per-file `authorizedKeysFile` binding and `authorizedKeys` computation in both `crdant.nix` and `chuck.nix` with `authorizedKeys = import ./authorized-keys.nix;`, keeping the existing `openssh.authorizedKeys.keys = authorizedKeys;` usage. The two files had independently pinned the same URL to different stale hashes, so a single source removes the drift and means future key changes are updated in one
place.

Verified with `nix-instantiate --parse` on all three files and by forcing evaluation of `darwinConfigurations.aguardiente.system.drvPath`, which resolves the new hash and exercises both users.
