### PR TITLE
Raise open-files limit for Nix

### DIFF
--- a/home/modules/base/fish.nix
+++ b/home/modules/base/fish.nix
@@ -25,6 +25,14 @@ in {
       if test -d $HOME/.rd
         fish_add_path --append $HOME/.rd/bin
       end
+
+      # Raise the open-files soft limit -- macOS defaults to 256, too low for
+      # Nix's parallel fetches (libgit2 tarball-cache "Too many open files").
+      if test (ulimit -Sn) != unlimited
+        if test (ulimit -Sn) -lt 65536
+          ulimit -Sn 65536
+        end
+      end
     '';
 
     interactiveShellInit = ''

--- a/home/modules/base/zsh.nix
+++ b/home/modules/base/zsh.nix
@@ -142,6 +142,12 @@ in {
       fi
 
       unset RPS1
+
+      # Raise the open-files soft limit -- macOS defaults to 256, too low for
+      # Nix's parallel fetches (libgit2 tarball-cache "Too many open files").
+      if [[ "$(ulimit -Sn)" != unlimited && "$(ulimit -Sn)" -lt 65536 ]]; then
+        ulimit -Sn 65536
+      fi
     '';
   };
 }


### PR DESCRIPTION
TL;DR
-----

Interactive shells now raise the open-files soft limit to 65536, so Nix's parallel fetches stop failing with "Too many open files" on macOS.

Details
-------

Raises `ulimit -Sn` to 65536 in the always-on shell init for both shells: fish's `shellInit` and zsh's `envExtra` (the `.zshenv` block that fish's `shellInit` already parities). macOS defaults this soft limit to 256, and Nix's parallel downloads exceed it -- the libgit2 tarball-cache aborts with "Too many open files" during operations such as `nix flake update`.

Guards the bump so it only ever raises the limit. The snippet is skipped when the current limit reports "unlimited" or is already at or above 65536, so a shell that inherited a higher limit is never lowered. It sits at the end of the same init block that already sets `XDG_CONFIG_HOME` and the rancher path, keeping fish and zsh in parity.
