### PR TITLE
Drop Bartender overlay for the unstable package

### DIFF
--- a/overlays/default.nix
+++ b/overlays/default.nix
@@ -40,33 +40,6 @@
 
     mas = final.unstable.mas;
 
-    bartender = prev.bartender.overrideAttrs (_oldAttrs: {
-      version = "6.5.2";
-
-      src = prev.fetchurl {
-        url = "https://downloads.macbartender.com/B2/updates/B6Latest/Bartender%206.dmg";
-        hash = "sha256-FVBgOJJYtabYXIUcbZgtsqJe5syV1HRcDfbZ8UkbJIQ=";
-      };
-
-      # undmg doesn't support APFS DMGs; use hdiutil directly instead
-      unpackCmd = ''
-        mnt=$(TMPDIR=/tmp mktemp -d -t nix-XXXXXXXXXX)
-        function finish { /usr/bin/hdiutil detach "$mnt" -force; rm -rf "$mnt"; }
-        trap finish EXIT
-        /usr/bin/hdiutil attach -nobrowse -mountpoint "$mnt" "$curSrc"
-        cp -a "$mnt/Bartender 6.app" "$PWD/"
-      '';
-
-      sourceRoot = ".";
-
-      installPhase = ''
-        runHook preInstall
-        mkdir -p "$out/Applications"
-        cp -r "Bartender 6.app" "$out/Applications/"
-        runHook postInstall
-      '';
-    });
-
     container = prev.container.overrideAttrs (oldAttrs: rec {
       version = "0.10.0";
       src = prev.fetchurl {

--- a/systems/modules/desktop/default.nix
+++ b/systems/modules/desktop/default.nix
@@ -65,7 +65,7 @@ in (lib.mkMerge [
         slack
         zoom-us
       ] ++ lib.optionals isDarwin [
-        bartender
+        unstable.bartender
         duti
         grandperspective
         hexfiend


### PR DESCRIPTION
TL;DR
-----

Removes the custom `bartender` overlay and pulls the maintained package from nixpkgs-unstable instead, eliminating the recurring hash-drift maintenance the overlay caused.

Details
-------

Drops the `bartender` attribute from `overlays/default.nix`. The overlay existed only because nixpkgs had fallen behind: it pinned version 6.5.2 and overrode `src` to fetch a DMG from a drift-prone "Latest" URL (`downloads.macbartender.com/.../B6Latest/Bartender%206.dmg`), which changed contents in place and forced periodic hash updates.

nixpkgs-unstable is now at bartender 6.5.2 — the exact version the overlay pinned — so the override no longer buys anything. Switches the darwin `environment.systemPackages` entry from the bare `bartender` to `unstable.bartender`, matching the existing pattern used for other unstable packages in that list (e.g. `unstable._1password-gui`). This lets Nix track nixpkgs's maintained source, with no "Latest"-URL hash to
keep chasing.

Verified: both edited files parse, `unstable.bartender` builds to `bartender-6.5.2`, and the full `aguardiente` darwin system still evaluates with the overlay removed (no other consumer depended on the
overridden package).
