### PR TITLE
Disable fish man-page completion generation

### DIFF
--- a/home/modules/base/fish.nix
+++ b/home/modules/base/fish.nix
@@ -7,6 +7,11 @@ in {
   programs.fish = {
     enable = true;
 
+    # fish 4.8+ dropped share/fish/tools/create_manpage_completions.py, which
+    # Home Manager's man-page completion generator invokes; disable it so the
+    # build doesn't fail. Built-in and package-vendored completions still work.
+    generateCompletions = false;
+
     shellAliases = {
       more = "less -X";
       pd = "pushd";


### PR DESCRIPTION
TL;DR
-----

Disables Home Manager's man-page completion generation for fish so the `home-manager-generation` build stops failing on hosts running fish 4.8+.

Details
-------

Sets `programs.fish.generateCompletions = false` in `home/modules/base/fish.nix`. Home Manager's completion generator invokes `share/fish/tools/create_manpage_completions.py`, which fish 4.8 removed. On the x86_64-linux host `mash` (which pulls fish 4.8.1) this breaks the `fish-completions` derivation ("python: can't open file ` .../create_manpage_completions.py': No such file or directory"), cascading through `crdant-fish-completions` to the whole `home-manager-generation`. Darwin currently pulls fish 4.7.1, which still ships the script, but that is temporary.

Disabling the option skips that derivation entirely. Built-in and package-vendored completions still work, so the day-to-day completion experience is unchanged. This can be re-enabled once Home Manager and fish support man-page completion generation on fish 4.8+.
