### PR TITLE
Refresh readwise-cli lockfile hash

### DIFF
--- a/pkgs/readwise-cli/default.nix
+++ b/pkgs/readwise-cli/default.nix
@@ -18,7 +18,7 @@ let
   # Fixed-output derivation: generates the lockfile from the package's own
   # package.json at build time. No lockfile committed to the repo.
   # To update: set lockHash = lib.fakeHash, build, copy the hash from the error.
-  lockHash = "sha256-ctZDqmv0Jug171Tb6uBfo3n097YtQ00nbnhgbQmHs84=";
+  lockHash = "sha256-aL98VCh/hhAoXDIyskPH96G35Kl0e1Cpdb70n4Sf9kw=";
   packageLock = runCommand "readwise-cli-lockfile-${version}" {
     nativeBuildInputs = [ nodejs cacert ];
     SSL_CERT_FILE = "${cacert}/etc/ssl/certs/ca-bundle.crt";
@@ -41,7 +41,7 @@ buildNpmPackage rec {
     cp ${packageLock} package-lock.json
   '';
 
-  npmDepsHash = "sha256-HOdNw7ahKvVMb5cOqZ8UgUNWivLlJAQqZuN6fijoTyc=";
+  npmDepsHash = "sha256-2yjyVQzQpWjvQN0nCqdEuETiKBIzSw9PJosEqbEDpJg=";
   dontNpmBuild = true;
 
   meta = with lib; {


### PR DESCRIPTION
TL;DR
-----

Refreshes the generated npm lockfile hash for `readwise-cli` so darwin
builds succeed again after a recent flake bump changed the node/npm that
generates the lockfile.

Details
-------

Updates `lockHash` in `pkgs/readwise-cli/default.nix`. The package does
not commit a lockfile; instead it regenerates one at build time as a
fixed-output derivation (`readwise-cli-lockfile-0.5.6`). That FOD's hash
depends on the node/npm doing the generation, so it drifts whenever
node/npm changes. The recent flake bump pulled a newer node/npm that
emits a slightly different lockfile, which broke the pinned hash and
failed darwin builds.

Also updates the coupled `npmDepsHash`. `buildNpmPackage` computes its
dependency hash from the generated lockfile, so regenerating the lockfile
necessarily changes `npmDepsHash` as well. This second hash was not
called out in the original scope, but the package cannot build without
it — a `lockHash`-only change swaps one hash-mismatch failure for
another one step downstream. Both values are the authoritative `got:`
hashes reported by building the derivations, not guesses.

Verified by building the package end to end for `aarch64-darwin`
(rebuilds the lockfile FOD and the npm package on top), producing
`readwise-cli-0.5.6` with no hash mismatches. Touches only
`pkgs/readwise-cli/default.nix`; the npm tarball `hash` and `version`
are unchanged.
