### PR TITLE
Refresh vault-gardener hashes

### DIFF
--- a/pkgs/vault-gardener/default.nix
+++ b/pkgs/vault-gardener/default.nix
@@ -19,7 +19,7 @@ let
     nativeBuildInputs = [ nodejs cacert ];
     outputHashAlgo = "sha256";
     outputHashMode = "flat";
-    outputHash = "sha256-fd7X/+iiVgTO2bYk+l96JmhBmjMWxzbrECs3M7/x4jM=";
+    outputHash = "sha256-hjF3p5pNtAox5bo8ZqQg5CBTmjxdPLwmPdOFdCERF1g=";
   } ''
     tar xzf ${tarball} --strip-components=1
     HOME=$TMPDIR npm install --package-lock-only --ignore-scripts
@@ -37,7 +37,7 @@ buildNpmPackage {
     cp ${packageLock} package-lock.json
   '';
 
-  npmDepsHash = "sha256-sxVT2F57M3qhYhBmUQVL5n112ZzmkVaq5cayuE3BQ5c=";
+  npmDepsHash = "sha256-7+aIZ4FFYLw79jSDioRg0Ds1zwF6i/9V9CnEszXCXdI=";
 
   dontNpmBuild = true;
 


### PR DESCRIPTION
TL;DR
-----

Refreshes both hashes in `pkgs/vault-gardener/default.nix` so darwin builds succeed again after a node/npm toolchain bump left them stale.

Details
-------

Updates the lockfile fixed-output derivation `outputHash` and the coupled `buildNpmPackage` `npmDepsHash`. The npm lockfile for this package is generated at build time by an FOD (`npm install --package-lock-only`), so its hash drifts whenever the node/npm toolchain changes — which a recent flake bump did. Because `buildNpmPackage` derives `npmDepsHash` from that generated lockfile, the two hashes move together: a regenerated lockfile always implies a new `npmDepsHash`. Both were stale, so the darwin build failed on hash mismatches.

Both hashes were taken from the actual `got:` output of a build against `aarch64-darwin` (registry.npmjs.org available), and the package now builds clean with no mismatch. No change to the npm tarball `hash` or the `version`; this follows the same pattern as the recent readwise-cli lockfile refresh.
