### PR TITLE
Raise Nix download-buffer-size

### DIFF
--- a/systems/modules/nix-core/default.nix
+++ b/systems/modules/nix-core/default.nix
@@ -36,6 +36,8 @@
   nix = {
     extraOptions = ''
       experimental-features = nix-command flakes
+      # bump from the 64 MiB default to quiet "download buffer is full" warnings
+      download-buffer-size = 268435456
       '';
 
     registry = {


### PR DESCRIPTION
TL;DR
-----

Raises Nix's `download-buffer-size` from the 64 MiB default to 256 MiB so large parallel fetches stop emitting "download buffer is full" warnings.

Details
-------

Adds `download-buffer-size = 268435456` to `nix.extraOptions` in `systems/modules/nix-core/default.nix`. That module is imported by every role (server, workstation, container, embedded, jumpbox), so the setting reaches all darwin and nixos hosts — including mash, where the warning was observed — without duplicating it across modules. Verified that mash's and a darwin host's rendered `nix.extraOptions` now carry the setting.
