### PR TITLE
Enable all terminfo

### DIFF
--- a/systems/modules/base/default.nix
+++ b/systems/modules/base/default.nix
@@ -81,7 +81,7 @@ in {
   # bash is enabled by default
 
   environment = {
-    # enableAllTerminfo = true;
+    enableAllTerminfo = true;
 
     systemPackages = with pkgs; [
       glow


### PR DESCRIPTION
TL;DR
-----

Enables `environment.enableAllTerminfo` in the shared base system module so the full terminfo database is installed system-wide, letting modern terminals like ghostty be recognized locally and over ssh.

Details
-------

Uncomments the previously-disabled `enableAllTerminfo = true;` line in `systems/modules/base/default.nix`. The option is a NixOS option, but the base module is shared across darwin and nixos hosts; both platforms evaluate cleanly with the change (verified against `nixosConfigurations.mash` and `darwinConfigurations.aguardiente`).

Installing the complete terminfo set avoids "unknown terminal type" errors for terminals whose entries are not in the default database, both at the local console and on remote hosts reached over ssh where `TERM` is propagated.
