### PR TITLE
Refresh tools and configs across base, homelab, and kubernetes modules

### DIFF
--- a/home/modules/base/default.nix
+++ b/home/modules/base/default.nix
@@ -151,6 +151,11 @@ in {
       flags = [
         "--disable-up-arrow"
       ];
+      settings = {
+        auto_sync = true;
+        sync_frequency = "5m";
+      };
+      forceOverwriteSettings = true;
     };
 
     bat = {

--- a/home/modules/base/fish.nix
+++ b/home/modules/base/fish.nix
@@ -52,7 +52,9 @@ in {
 
       # On desktop, ensure gpg-agent is running and use it for SSH
       # (replaces oh-my-zsh gpg-agent plugin which only handled zsh)
-      if test -z "$SSH_TTY"
+      # SSH_CONNECTION is set by sshd and inherited by tmux, so it distinguishes
+      # remote sessions (including tmux panes) from a local desktop.
+      if test -z "$SSH_TTY" && test -z "$SSH_CONNECTION"
         gpg-connect-agent /bye >/dev/null 2>&1
         set gpg_ssh_sock (gpgconf --list-dirs agent-ssh-socket 2>/dev/null)
         if test -n "$gpg_ssh_sock"

--- a/home/modules/base/zsh.nix
+++ b/home/modules/base/zsh.nix
@@ -70,7 +70,9 @@ in {
 
         # On desktop, ensure gpg-agent is running and use it for SSH
         # (makes zsh self-contained; also handled by oh-my-zsh gpg-agent plugin)
-        if [[ -z "$SSH_TTY" && -n "$GPG_AGENT_SSH_SOCK" ]]; then
+        # SSH_CONNECTION is set by sshd and inherited by tmux, so it distinguishes
+        # remote sessions (including tmux panes) from a local desktop.
+        if [[ -z "$SSH_TTY" && -z "$SSH_CONNECTION" && -n "$GPG_AGENT_SSH_SOCK" ]]; then
           gpg-connect-agent /bye >/dev/null 2>&1
           GPG_AGENT_SSH_SOCK=$(gpgconf --list-dirs agent-ssh-socket 2>/dev/null)
           export SSH_AUTH_SOCK="$GPG_AGENT_SSH_SOCK"

--- a/home/modules/homelab/default.nix
+++ b/home/modules/homelab/default.nix
@@ -10,6 +10,7 @@ in {
       knot-dns
       minio-client
       powershell
+      seaweedfs
     ] ++ lib.optionals isDarwin [
       tart
     ];

--- a/home/modules/kubernetes/default.nix
+++ b/home/modules/kubernetes/default.nix
@@ -13,6 +13,7 @@ in {
       istioctl
       krew
       kubectl
+      kubectl-refresh-config
       k0sctl
       k9s
       kapp

--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -30,6 +30,8 @@ rec {
   vault-gardener = pkgs.callPackage ./vault-gardener { };
   obsidian-headless = pkgs.callPackage ./obsidian-headless { };
 
+  kubectl-refresh-config = pkgs.callPackage ./kubectl-refresh-config { };
+
   # simonw tools
   claude-code-transcripts = pkgs.callPackage ./claude-code-transcripts { };
   ttok = pkgs.callPackage ./ttok { };

--- a/pkgs/kubectl-refresh-config/default.nix
+++ b/pkgs/kubectl-refresh-config/default.nix
@@ -1,0 +1,14 @@
+{ pkgs }:
+
+pkgs.writeShellApplication {
+  name = "kubectl-refresh_config";
+  runtimeInputs = with pkgs; [ findutils coreutils kubectl ];
+  text = ''
+    kubeconfig_path=$(find "$HOME/.kube" -maxdepth 1 -name '*.kubeconfig' | paste -sd ':')
+    if [[ -z "$kubeconfig_path" ]]; then
+      echo "No .kubeconfig files found in $HOME/.kube" >&2
+      exit 1
+    fi
+    KUBECONFIG="$kubeconfig_path" kubectl config view --merge --flatten > "$HOME/.kube/config"
+  '';
+}

--- a/pkgs/obsidian-headless/default.nix
+++ b/pkgs/obsidian-headless/default.nix
@@ -5,11 +5,11 @@
 
 buildNpmPackage rec {
   pname = "obsidian-headless";
-  version = "0.0.8";
+  version = "0.0.14";
 
   src = ./.;
 
-  npmDepsHash = "sha256-6PtdFej18oE7/vH07eBJTDMew4wrQkhPYozhNxgDG4s=";
+  npmDepsHash = "sha256-BfccB+FZgHt07hMdlXxEDcjo1zMVgXgJlX5BLgnopps=";
   dontNpmBuild = true;
 
   postInstall = ''

--- a/pkgs/obsidian-headless/package-lock.json
+++ b/pkgs/obsidian-headless/package-lock.json
@@ -1,14 +1,14 @@
 {
   "name": "obsidian-headless-wrapper",
-  "version": "0.0.8",
+  "version": "0.0.14",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "obsidian-headless-wrapper",
-      "version": "0.0.8",
+      "version": "0.0.14",
       "dependencies": {
-        "obsidian-headless": "0.0.8"
+        "obsidian-headless": "0.0.14"
       }
     },
     "node_modules/base64-js": {
@@ -32,9 +32,9 @@
       "license": "MIT"
     },
     "node_modules/better-sqlite3": {
-      "version": "12.6.2",
-      "resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-12.6.2.tgz",
-      "integrity": "sha512-8VYKM3MjCa9WcaSAI3hzwhmyHVlH8tiGFwf0RlTsZPWJ1I5MkzjiudCo4KC4DxOaL/53A5B1sI/IbldNFDbsKA==",
+      "version": "12.11.1",
+      "resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-12.11.1.tgz",
+      "integrity": "sha512-dq9AtApgg5PGFtBzPFSBl3HZQjHok5gaQCM6zh2Yk0aSmDCs1CbnVI8/HgASQkNKsWFpseIO9beg5xxpYhbIfA==",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
@@ -42,7 +42,7 @@
         "prebuild-install": "^7.1.1"
       },
       "engines": {
-        "node": "20.x || 22.x || 23.x || 24.x || 25.x"
+        "node": "20.x || 22.x || 23.x || 24.x || 25.x || 26.x"
       }
     },
     "node_modules/bindings": {
@@ -239,9 +239,9 @@
       "license": "MIT"
     },
     "node_modules/node-abi": {
-      "version": "3.89.0",
-      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.89.0.tgz",
-      "integrity": "sha512-6u9UwL0HlAl21+agMN3YAMXcKByMqwGx+pq+P76vii5f7hTPtKDp08/H9py6DY+cfDw7kQNTGEj/rly3IgbNQA==",
+      "version": "3.94.0",
+      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.94.0.tgz",
+      "integrity": "sha512-W5ZNO5KRPB5TkYmGVD9F6YqhsglXJzE6etpbmT+f6EQElhiX/UTG551cnsRGvLG3fyZEg9HwaDmNmj5nwJ4z9g==",
       "license": "MIT",
       "dependencies": {
         "semver": "^7.3.5"
@@ -251,21 +251,12 @@
       }
     },
     "node_modules/obsidian-headless": {
-      "version": "0.0.8",
-      "resolved": "https://registry.npmjs.org/obsidian-headless/-/obsidian-headless-0.0.8.tgz",
-      "integrity": "sha512-rBl295dIbTxEY4nl3fFue18qFPdU/ASUOLicg+1pa3suBRtJR8lKCoLFkhcg1VApSGujDjgcOiTqAsu5cnq/3w==",
-      "cpu": [
-        "x64",
-        "arm64"
-      ],
+      "version": "0.0.14",
+      "resolved": "https://registry.npmjs.org/obsidian-headless/-/obsidian-headless-0.0.14.tgz",
+      "integrity": "sha512-S1d/hxLKvCUG2g5tRyXFkzPqMs3Ntw1tDyzoF2yfHGRuB4B+Mi3X2vgT8LbfQKrkEEi3LfJRdXtYzAVHcbpccw==",
       "license": "UNLICENSED",
-      "os": [
-        "darwin",
-        "linux",
-        "win32"
-      ],
       "dependencies": {
-        "better-sqlite3": "12.6.2",
+        "better-sqlite3": "12.11.1",
         "commander": "14.0.3"
       },
       "bin": {
@@ -371,9 +362,9 @@
       "license": "MIT"
     },
     "node_modules/semver": {
-      "version": "7.7.4",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
-      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -446,9 +437,9 @@
       }
     },
     "node_modules/tar-fs": {
-      "version": "2.1.4",
-      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.4.tgz",
-      "integrity": "sha512-mDAjwmZdh7LTT6pNleZ05Yt65HC3E+NiQzl672vQG38jIrehtJk/J3mNwIg+vShQPcLF/LV7CMnDW6vjj6sfYQ==",
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.5.tgz",
+      "integrity": "sha512-OboTd8mmMhZDNPV+UjQcK9yKAatXu2aJ+r1w4im1Otd4M4fl2hwvdoXUxIYHFTHWK/3y3FarBP70v3vwmGlOxw==",
       "license": "MIT",
       "dependencies": {
         "chownr": "^1.1.1",

--- a/pkgs/obsidian-headless/package.json
+++ b/pkgs/obsidian-headless/package.json
@@ -1,8 +1,8 @@
 {
   "name": "obsidian-headless-wrapper",
-  "version": "0.0.8",
+  "version": "0.0.14",
   "description": "Nix wrapper for obsidian-headless",
   "dependencies": {
-    "obsidian-headless": "0.0.8"
+    "obsidian-headless": "0.0.14"
   }
 }


### PR DESCRIPTION
TL;DR
-----

Batch of small refreshes: enables atuin auto-sync, bumps obsidian-headless to 0.0.14, adds seaweedfs to the homelab packages, adds a `kubectl refresh-config` plugin, and fixes gpg-agent SSH hijacking in remote tmux sessions.

Details
-------

Enables atuin's built-in sync with a five-minute frequency so shell history stays current across machines, using `forceOverwriteSettings` so Home Manager owns the settings file.

Updates obsidian-headless to 0.0.14, bumping the wrapper's package.json and lockfile along with the derivation version and refreshing `npmDepsHash`. Verified the package builds at the new version.

Adds seaweedfs to the homelab package set.

Adds a `kubectl refresh-config` plugin that merges all `~/.kube/*.kubeconfig` files into `~/.kube/config`, so per-cluster configs stay separate while kubectl sees them all.

Skips gpg-agent SSH setup when `SSH_CONNECTION` is set, not just `SSH_TTY` — tmux panes on remote hosts don't inherit `SSH_TTY`, so they were hijacking `SSH_AUTH_SOCK` away from the forwarded agent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
