### PR TITLE
Add Avante.nvim with Kimi K2.x via OpenRouter

### DIFF
--- a/docs/plans/2026-05-11-003-feat-avante-nvim-integration-plan.md
+++ b/docs/plans/2026-05-11-003-feat-avante-nvim-integration-plan.md
@@ -1,0 +1,235 @@
+---
+status: completed
+created: 2026-05-11
+---
+
+# Add Avante.nvim to AI Module
+
+## Problem Frame
+
+The user wants to integrate [Avante.nvim](https://github.com/yetone/avante.nvim) — a Neovim plugin that emulates the Cursor AI IDE — into their dotfiles' AI home-manager module (`home/modules/ai/`). Avante.nvim provides AI-powered code assistance directly within Neovim, offering an experience similar to Cursor's AI chat and code generation features.
+
+Currently, the `ai` module contains non-agentic shared AI tools (ollama, llm, mods, fabric-ai, etc.) but has no Neovim integration. Adding Avante.nvim will bring AI-assisted editing capabilities into the editor, complementing the existing OpenCode agent workflow rather than replacing it.
+
+## Scope Boundaries
+
+### In Scope
+- Install `avante-nvim` and its required dependencies via the `ai` home-manager module
+- Configure Avante.nvim with sensible defaults that work alongside OpenCode
+- Use Kimi K2.x via OpenRouter as the default provider (user preference)
+- Integrate with existing editor tooling (snacks.nvim input, fzf/telescope file selection)
+- Add required dependency plugins (`nui.nvim`, `render-markdown.nvim`)
+
+### Deferred for Later
+- Custom keybinding overrides (user can extend via personal config)
+- Advanced provider configurations beyond OpenRouter (e.g., Claude, OpenAI)
+- Custom prompts or shortcuts definitions
+- Avante.nvim build-from-source configuration (use prebuilt binary)
+
+### Outside This Product's Identity
+- Replacing OpenCode with Avante.nvim as primary agent
+- Adding Avante.nvim to non-AI profiles (minimal, server)
+- Configuring Avante.nvim as a standalone agent CLI (Zen mode is out of scope)
+
+## Requirements Traceability
+
+| Requirement | Source | Implementation |
+|---|---|---|
+| Install Avante.nvim | Feature request | U1: Add package and dependencies |
+| Rational defaults for OpenCode | Feature request | U2: Lua configuration |
+| Use Kimi as AI provider | User request | U2: OpenRouter provider (Kimi K2.x), new SOPS secrets |
+| No conflict with OpenCode | Implicit | U2: Separate keybindings, dedicated API keys |
+
+## Key Technical Decisions
+
+**1. Module placement: `home/modules/ai/default.nix`**
+Rationale: The user explicitly requested the "AI home manager module." While Avante.nvim is agentic in nature, it serves as an editor-embedded AI assistant rather than a standalone agent like OpenCode or Claude Code. The `ai` module is the shared AI infrastructure module, and Avante.nvim complements all agent workflows rather than belonging to one specific agent module.
+
+**2. Default provider: Kimi K2.x via OpenRouter**
+Rationale: The user explicitly requested Kimi as the AI model for Avante.nvim, served through OpenRouter rather than a direct Moonshot or Fireworks account. OpenRouter exposes an OpenAI-compatible API, so Avante's `__inherited_from = "openai"` vendor pattern applies. The model is `moonshotai/kimi-k2.7-code`, the coding-tuned member of the K2.x line (262k context). This requires SOPS-managed secrets for the OpenRouter API keys.
+
+**3. Input provider: `snacks`**
+Rationale: The editor module already installs and configures `snacks.nvim`. Using snacks as the input provider provides a consistent UI experience without adding new dependencies.
+
+**4. File selector: `fzf`**
+Rationale: The editor module already has `fzf-vim` configured. Using fzf-lua or native fzf integration provides consistent file selection.
+
+**5. API key strategy: `OPENROUTER_API_KEY` from a single SOPS secret**
+Rationale: The standard `OPENROUTER_API_KEY` variable is set in both zsh and fish from a single SOPS-managed secret (`openrouter/apiKey`), following the pattern used for OpenCode secrets.
+
+## Implementation Units
+
+### U1. Add Avante.nvim Package and Dependencies
+
+**Goal:** Install `avante-nvim` and its required dependency plugins in the AI module.
+
+**Requirements:** Install Avante.nvim
+
+**Dependencies:** None
+
+**Files:**
+- `home/modules/ai/default.nix`
+
+**Approach:**
+Add Neovim plugin configuration to the `ai` module. The module currently has no `programs.neovim` section, so this is a new addition.
+
+Required packages to add (declare in this order to ensure dependency loading):
+- `pkgs.vimPlugins.nui-nvim` (required dependency — must load before avante)
+- `pkgs.vimPlugins.render-markdown-nvim` (required dependency for rendering — must load before avante)
+- `pkgs.vimPlugins.avante-nvim` (main plugin)
+
+Optional but recommended:
+- `pkgs.vimPlugins.img-clip-nvim` (image paste support)
+
+The `ai` module should declare `programs.neovim.plugins` and `programs.neovim.extraLuaConfig`. Use `lib.mkAfter` for the Lua config to ensure it loads after the base editor configuration.
+
+**Patterns to follow:**
+- See `home/modules/claude/default.nix:148-158` for agent-specific Neovim plugin pattern
+- See `home/modules/editor/default.nix:14-161` for core editor plugin declarations
+
+**Test scenarios:**
+- Happy path: `home-manager switch` succeeds without errors
+- Integration: Neovim starts without plugin load errors (`nvim --headless -c 'qa'`)
+- Integration: Avante initializes correctly (`nvim --headless -c 'lua require("avante").setup({})' -c 'qa'`)
+- Verification: `:checkhealth avante` shows required dependencies satisfied
+
+---
+
+### U2. Configure Avante.nvim with OpenCode-Friendly Defaults
+
+**Goal:** Add Lua configuration for Avante.nvim that integrates well with the existing dotfiles setup and OpenCode workflow.
+
+**Requirements:** Rational defaults for OpenCode
+
+**Dependencies:** U1
+
+**Files:**
+- `home/modules/ai/default.nix` (Lua config addition)
+
+**Approach:**
+Add `programs.neovim.extraLuaConfig` with Avante.nvim setup:
+
+1. **Provider configuration:** Use Kimi K2.x served through OpenRouter's OpenAI-compatible endpoint
+2. **Input provider:** Use `snacks` (already installed in editor module)
+3. **File selector:** Use `fzf` (already available via fzf-vim)
+4. **Keymap prefix:** Use `<leader>a` (consistent with Avante defaults, doesn't conflict with OpenCode)
+5. **Window position:** `right` (standard sidebar position)
+6. **Auto-suggestions:** Disabled by default (avoid conflicts with supermaven-nvim in editor module)
+7. **Instructions file:** `avante.md` (default, for project-specific prompts)
+8. **Behaviour settings:** Enable token counting, auto-add current file, use inline buttons for confirmation
+
+**Environment variables:**
+Add `OPENROUTER_API_KEY` to the zsh and fish environments from the `openrouter/apiKey` SOPS secret, matching the pattern used for OpenCode secrets in `home/modules/opencode/default.nix:103-111`.
+
+**New SOPS secret required:**
+- Add `openrouter/apiKey` to `home/modules/ai/default.nix` sops.secrets
+- The implementer must add the corresponding secret to their SOPS-encrypted secrets file (e.g., `home/users/crdant/secrets.yaml`)
+
+**Lua configuration pattern:**
+Follow the `lib.mkAfter` pattern from `home/modules/claude/default.nix:154` to ensure Avante loads after core editor setup.
+
+**Technical design (directional guidance):**
+```lua
+-- This illustrates the intended configuration approach
+require('avante').setup({
+  provider = "openrouter",
+  auto_suggestions_provider = "openrouter",
+  providers = {
+    openrouter = {
+      __inherited_from = "openai",
+      endpoint = "https://openrouter.ai/api/v1",
+      api_key_name = "OPENROUTER_API_KEY",
+      model = "moonshotai/kimi-k2.7-code",  -- Update to latest Kimi K2.x model as of implementation date
+      timeout = 30000,
+      extra_request_body = {
+        temperature = 0.75,
+        max_tokens = 32768,
+      },
+    },
+  },
+  input = {
+    provider = "snacks",
+    provider_opts = {
+      title = "Avante Input",
+      icon = " ",
+    },
+  },
+  selector = {
+    provider = "fzf",  -- Use "fzf_lua" if fzf-lua is installed; "fzf" for fzf-vim
+  },
+  behaviour = {
+    auto_suggestions = false,
+    auto_set_keymaps = true,
+    auto_apply_diff_after_generation = false,
+    enable_token_counting = true,
+    auto_add_current_file = true,
+    auto_approve_tool_permissions = true,
+    confirmation_ui_style = "inline_buttons",
+  },
+  windows = {
+    position = "right",
+    width = 30,
+    input = {
+      prefix = "> ",
+      height = 8,
+    },
+  },
+})
+```
+
+**Patterns to follow:**
+- `home/modules/claude/default.nix:148-158` for agent neovim plugin + Lua config
+- `home/modules/opencode/default.nix:103-111` for SOPS secret environment variable pattern
+- `home/modules/opencode/default.nix:114-123` for fish shell equivalent
+
+**Test scenarios:**
+- Happy path: `:AvanteAsk` opens the sidebar without errors
+- Integration: Avante sidebar renders markdown correctly (requires render-markdown-nvim)
+- Integration: File selector works with fzf (`@file` mention triggers fzf)
+- Integration: Input dialog uses snacks UI
+- Error path: Graceful handling when `OPENROUTER_API_KEY` is unset (Avante prompts for key)
+- Edge case: Multiple Neovim plugin configs merge correctly (base + editor + ai + claude module)
+
+**Verification:**
+- `darwin-rebuild switch` or `home-manager switch` succeeds
+- `nvim --headless -c 'qa'` exits without errors
+- Open Neovim, verify `:AvanteAsk` opens sidebar
+- Verify `<leader>aa` keybinding works
+- Check that existing OpenCode workflow is unaffected
+
+## Deferred Questions
+
+- **Q1: Should Avante.nvim be added to specific profiles only?** The `ai` module is already imported by `full.nix` and `development.nix` profiles. No action needed unless user wants to restrict it.
+- **Q2: Should we enable auto-suggestions?** Currently set to `false` to avoid conflict with `supermaven-nvim` in the editor module. Can be enabled later if user prefers Avante suggestions over Supermaven.
+
+## Dependencies / Prerequisites
+
+- `avante-nvim` must be available in nixpkgs (confirmed: `vimPlugins.avante-nvim` exists in unstable)
+- Neovim 0.11+ (the dotfiles already use a recent Neovim version)
+- Existing `snacks.nvim` in editor module (confirmed in `home/modules/editor/default.nix`)
+- Existing `fzf-vim` in editor module (confirmed in `home/modules/editor/default.nix`)
+- New OpenRouter API key SOPS secret must be added to `home/modules/ai/default.nix` and the user's encrypted secrets file
+- Existing SOPS infrastructure (confirmed in `home/modules/ai/default.nix`)
+
+## Risk Analysis & Mitigation
+
+| Risk | Likelihood | Impact | Mitigation |
+|---|---|---|---|
+| `avante-nvim` nixpkgs version is outdated | Low | Medium | Check version on install; if too old, consider overlay or build from source |
+| Lua config conflicts with existing plugins | Medium | Low | Use `lib.mkAfter` to load after base config; test `:checkhealth` |
+| API key environment variable conflicts | Low | Medium | `OPENROUTER_API_KEY` is the standard variable; other tools using OpenRouter share the same account intentionally |
+| Neovim startup time increase | Low | Low | Avante is lazy-loaded by default; minimal impact |
+
+## Documentation Plan
+
+- Add a brief comment in `home/modules/ai/default.nix` explaining the Avante.nvim configuration
+- The `avante.md` file convention for project-specific instructions is documented upstream; no additional docs needed
+
+## Success Criteria
+
+1. `home-manager switch` completes without errors
+2. Neovim starts and Avante.nvim loads (`:AvanteAsk` works)
+3. Avante sidebar opens with Kimi K2.x (via OpenRouter) configured
+4. File selector, input UI, and markdown rendering function correctly
+5. Existing OpenCode workflow remains unaffected
+6. OpenRouter API key is sourced from SOPS secrets without manual configuration (secret must be added to encrypted secrets file before deployment)

--- a/home/modules/ai/default.nix
+++ b/home/modules/ai/default.nix
@@ -61,6 +61,7 @@ in {
         "firecrawl/api_key" = {};
         "omni/api_token" = {};
         "shortcut/api_token" = {};
+        "openrouter/apiKey" = {};
       };
     };
 
@@ -71,6 +72,82 @@ in {
           source = ./config/llm/templates;
           recursive = true;
         };
+      };
+    };
+
+    programs = {
+      # Avante.nvim — AI-powered editing assistant for Neovim
+      neovim = {
+        plugins = with pkgs.vimPlugins; [
+          nui-nvim
+          render-markdown-nvim
+          avante-nvim
+          img-clip-nvim
+        ];
+
+        extraLuaConfig = lib.mkAfter ''
+          -- Avante.nvim configuration
+          -- AI-powered code assistance within Neovim, complementing OpenCode
+          -- Uses Kimi K2.x via OpenRouter (OpenAI-compatible API)
+          require('avante').setup({
+            provider = "openrouter",
+            auto_suggestions_provider = "openrouter",
+            providers = {
+              openrouter = {
+                __inherited_from = "openai",
+                endpoint = "https://openrouter.ai/api/v1",
+                api_key_name = "OPENROUTER_API_KEY",
+                model = "moonshotai/kimi-k2.7-code",
+                timeout = 30000,
+                extra_request_body = {
+                  temperature = 0.75,
+                  max_tokens = 32768,
+                },
+              },
+            },
+            input = {
+              provider = "snacks",
+              provider_opts = {
+                title = "Avante Input",
+                icon = " ",
+              },
+            },
+            selector = {
+              provider = "fzf",
+            },
+            behaviour = {
+              auto_suggestions = false,
+              auto_set_keymaps = true,
+              auto_apply_diff_after_generation = false,
+              enable_token_counting = true,
+              auto_add_current_file = true,
+              auto_approve_tool_permissions = true,
+              confirmation_ui_style = "inline_buttons",
+            },
+            windows = {
+              position = "right",
+              width = 30,
+              input = {
+                prefix = "> ",
+                height = 8,
+              },
+            },
+          })
+        '';
+      };
+
+      zsh = {
+        envExtra = ''
+          # Avante.nvim OpenRouter API key
+          export OPENROUTER_API_KEY="$(cat ${config.sops.secrets."openrouter/apiKey".path})"
+        '';
+      };
+
+      fish = {
+        shellInit = ''
+          # Avante.nvim OpenRouter API key
+          set -gx OPENROUTER_API_KEY (cat ${config.sops.secrets."openrouter/apiKey".path})
+        '';
       };
     };
   };

--- a/home/users/crdant/secrets.yaml
+++ b/home/users/crdant/secrets.yaml
@@ -1,69 +1,71 @@
 github:
-    token: ENC[AES256_GCM,data:38/h/WJadwPBm1WRsJzyFXQPBccYvKXhox2XhJ9nLoe0Mj2Ebrxc6w==,iv:pqkLZ5RQbJ5qrpg0iO7+aEa3VHuj4XL5mJKg+c+ia5U=,tag:+prMiNXMh8c9nNw8Vr4p0Q==,type:str]
+    token: ENC[AES256_GCM,data:AHF35q58/mxE30FShz3jtkqMjWIGiKomtwFfLhcaul4M0SOaAhhGuQ==,iv:A7nsR8aSez4xNZTwYHqvRzAIAW6O4TBhlM1PSe04fCU=,tag:9TUj45AW7AektWxAwl3xDw==,type:str]
 anthropic:
     apiKeys:
-        chuck@replicated.com: ENC[AES256_GCM,data:EVK4hyLatOjjeYERZyGfHVJGsHBjCohs0WdOfEUQrSWaidDMb40R6+cBEA9pAESwphB2Rvj9lJPvBKVNyKEF4521Em4F6tuIdPLbbruWzMx9FtOI3prEdN5QGz+0keLRF9yLGTNkIwA8ULY=,iv:ZdMecYxtkYytNMmBkB/Zs2hNLl7bSQpzTpyRgGhvZO4=,tag:DGX+xdfh+pvJBZzrHfZWQg==,type:str]
-        chuck@crdant.io: ENC[AES256_GCM,data:uq9AybpPIdcJbfO9ITkgo/U57Asir4qyjVU+RVR2SPrEhzvbNvjyPxTyGGMxkuoTKv1CT03HnbdkfQjEKcjAO67PYnhm+9ip7RX/yx8gD0NUx/GPlb4m4c71WPiMPPOtH5IIXqI3qN25xab8,iv:K55V61VhjmiDOso05r+h3OBluTLfsx9Iv381GsoVW1A=,tag:tahyIUL36uwQq3fxfdyGHg==,type:str]
+        chuck@replicated.com: ENC[AES256_GCM,data:yRklqjNdbOr4qRuTKbrc868BeMEFqDLDIIzzD4Xgrx4JU0cT5vlUsDkTZWOymjA1MYSqXBZHlIKRPmJDMbCV7HF1XQN/4OVPFYxmnqQkr0ARpztI/7rb8t28gasLtnMf281555gqw+Y9noE=,iv:xpCAEwkgenyVcs8pNXS0WRQr7dBzy3OtVVl5jTcly30=,tag:6AliGEsJmxsjXMSXAqfhLg==,type:str]
+        chuck@crdant.io: ENC[AES256_GCM,data:2yjylcytgbWt/HJOPIER3fXNNhqxd+LCOyJth00t4yZPo2W6fVylz38lL3/ZLj+3jBe8YGlSwvaGbEpJ5oL4W55DZLgU/2WssXK0z1MErfERHPeyQGbOx+8/8sIrnTwtUXuhjPcUX9ScCE/i,iv:LOI633HNvHPl7hIrzSLEHLMcz8HcdGTL3PNlf8/3MRY=,tag:2VpPk7F90xivut4XSEMiCQ==,type:str]
 google:
     maps:
-        apiKey: ENC[AES256_GCM,data:Fu6X/mDR3mMHVstacw3D77aVk5q4G26YMFm7InyfL5xZJGIAbfbD,iv:fkAFXiJ3IFUPIC+OXpgD1wzeQAL9+fqfIQQySE6Q7cM=,tag:RdxdhkB0BEV57q3eb5Si9w==,type:str]
+        apiKey: ENC[AES256_GCM,data:Oeg4QXDP2ox5xjIFNYM0Q+ryqA2E8aFXmJPKUdbJyCuN3XPDV2Qi,iv:SUv4Zf84dt//5IXl3w6jcvY44LPemtpFUhHKHI5adb4=,tag:BSfD614Gca5+tF+BHd2g9A==,type:str]
 slack:
     shortrib:
         slackernews:
-            userToken: ENC[AES256_GCM,data:q61rSwNFU7Wmw7jMfQxW0QBFyrXs2vx4loMENAa6l6LT+e93e7K6Pe3fL1WHgy3pY384uWb5uz3wVjgJag/EZPphq/DlbZxstNEY5KRXdg==,iv:Kp57ZiJJSdZyDruaheIfndVihifGjOOfK9bzl9BmM9w=,tag:UybrOK/3uAdj2ZQ4IsSDpw==,type:str]
-            botToken: ENC[AES256_GCM,data:fJWINXv9ZP9YiMFBhc4Elo+k3emc2t9vE1+n+Vh7OGIPJoIpdNCoU05JA5OGEbwpVSMjNukANYX6,iv:W/rf52+XZtOn4FBho1T3Z0MYq7V43cscgAmBEgtNTZ8=,tag:4CmQdoXrLarrp/wcEDP3nA==,type:str]
+            userToken: ENC[AES256_GCM,data:eyKSZWKjbIWxgSU5qR9c2ll5lDph7PnT0SqSxOK8B3NsluRwkduv6dk60CpcZBbEV0i17j0D/Yu4RZ4CjhoJFEw33isDd/iiVe2fhj2GbA==,iv:ESrFQwiQ0lqRI5JMdSt+t59nn7njaPxmYOQM4PP5AKI=,tag:7ro3SLEFqDulVLLHiXTZSw==,type:str]
+            botToken: ENC[AES256_GCM,data:AI5HwehHNzwTfG6JJUEGV9yj0Lws3UHBtM/5GmNU4KwhxwS0mA+2J07RHPW4IOe03SRn8XLEOGcE,iv:YkMredD9BJwcxZGZtmuNZfHL98uDvdeHq22BpfE8wJ0=,tag:E88Pt/VBG3Wp3vn4rZzEIQ==,type:str]
 mbta:
-    apiKey: ENC[AES256_GCM,data:/pdknNEwYhr5v+kUKvslW8vzkw5uAEd5gae07DHgWIo=,iv:3dJfrLHhLkI+7rfUB2L+h46GevGyr7XPE3uwkfNAhuQ=,tag:mGEgRuX6WrGwI6/d0UrlHQ==,type:str]
+    apiKey: ENC[AES256_GCM,data:0X8CQvEdXpN6KH6cfQSvHYUkcnTTPJ/u2qNiVd1bsnA=,iv:OT6BcDpROvBM6I0AbUKaUJnYJSqkIME6AQDiZNmHZmg=,tag:QMcRh0E++SulRxWzpcqCTA==,type:str]
 omni:
-    api_token: ENC[AES256_GCM,data:SEwCwthiRhjrd8Odnf8cb/VYq2i6dLZDMCcKPK9TyR1PCIAO1aDeNuKCrDRbRwl6bl2JI3j77OOoWzYdlKmitPg=,iv:0RxErEhGBx1rruKPZxvorijIEput8a4yDvG//oe42zs=,tag:FhbCa5xzyPUYPygP/4+0ug==,type:str]
+    api_token: ENC[AES256_GCM,data:C52tRvo1YrzZpNi9C4dAhpkWFt4eLvblBONleRPyNOgv8uSOUDDcP3Dt/Pv3pWtdWgw1tv2Vl3fUn7bbzWG7LOI=,iv:N84Fa59n+FrB8XTzl6BKaNy9XJDK03KBtknNxmO7MX8=,tag:Y8c30AX2J9SwKoRsFlKf/w==,type:str]
 firecrawl:
-    api_key: ENC[AES256_GCM,data:mBmW0xK+XrXSRtOeYs0nij4dWWvqRsNKb4MIxJhE+ymDkgE=,iv:QAlbyTqOBF+tFDd+pxpV3k8A1y+aLC6Cr53HPNrj90s=,tag:HQlhqICH0uuHWSPN7wuO/w==,type:str]
+    api_key: ENC[AES256_GCM,data:hfyMTs/2SutXwwVvz8wLCqJRydpG0bzXuK98qobHoQe5oj4=,iv:88rN0hEwd40l0yc9YWltn7Px759BdCCsrWUeUZ9Tink=,tag:GXbr8h/AfFya6ORC6R7mGQ==,type:str]
 atproto:
     pds:
-        adminPassword: ENC[AES256_GCM,data:+oMMjXvCdZA2/cwJrT/dOxzpCwDiroNLhM9y8x5OEBE=,iv:tl5gAdQn7e6nL+KnExGxUsmWW74Dtfwb9YmlV1q1/kg=,tag:vWgzYOvTXZ5jAyRa9KVE9Q==,type:str]
+        adminPassword: ENC[AES256_GCM,data:8Z9D9G/lx76dhD68ESRu2SJKJsqE3GM6vhtGWmSKiMw=,iv:C5P2VGs4mOjQKqABrrOa1MbLhJLOUWaMsvWi5dlsKLM=,tag:9Fps+Wx4fcxrKoGluB0HCQ==,type:str]
+openrouter:
+    apiKey: ENC[AES256_GCM,data:4/l2dmnu+wXfGqNgLk5z43cJoIoRtaXEkUVzdIwn7AdPFifpIAUD188bVpFZhcSkKvTra2Szg6Gr11uHfNPiUVZlwnmMQ6XvoA==,iv:HBlL3gyaktvl/HSZaTBYq0DQzNX/oj/jR/J9QgC5ixI=,tag:HrECCBXR2dMf2LBbEU0Aow==,type:str]
 shortcut:
-    api_token: ENC[AES256_GCM,data:ztVsx+U6hAwORBfrSkqp0qjxBx6pqEfVtKoH8VRk+EWY7m1OjG6NI6I5uf39cb2aDizN4/4059XJ1BYEjKjtguKgvDY+naed5RPehSpdCc8sjUL4wUopboiq/siAPlHMVhcT7gQHQKmewWHCufjdyBjLp4W5e6J+4ow64qW0BnA5noGs55DXmQEdcsyqomg6o6j2buUQ+uWyfzHLkVK/AA==,iv:Refp9SUgKxTQxUAc8JOwXQGBRLBTUfu9Mc8Ipmu3eVs=,tag:rRKOzHDK/kmba5ftsFfyEg==,type:str]
+    api_token: ENC[AES256_GCM,data:pBJdGAUV6Dz1+x275YYGiNsPO2pPPS/fpQYQLehxSajtLxY5gzy8GCsRWpGPBXg1uPZZrwzX6Rw0gIwaUpiWL4NuDRtoCLSvj9jb66H6kmAaXToUXKi3Dh7AQftmc1XcCR0rFXC1aA532hNXNmVS8Ms8FIvBUNyUZa5gKBpsIIGTqin4PkSKW2hz+WH1xKrnsZEURP3LenNL++eIBT/9KA==,iv:LRa7F8gJ/7rahmIFzL8M/2iJ62roBD/bkrSSMVi65rE=,tag:IDr3tHR9/K1vv8XVmireVw==,type:str]
 snowflake:
-    private_key: ENC[AES256_GCM,data:Qaeqaj7dDuMrVJE7LqYwbrQr+mW+KEexx4KJhT/I0Z/8AXKtmCDXMUg4CzgBKn60X5SBHjGfJvcvti+B6X+KB16WQ1lk0K1fk+frs4PhteD10sOm6CAJRdO5/MUOKVRRQ2Z6Z/QN3yCXKEWxeP3RldQjf7JmXO2ZMc/nCm7IJ+nRWM2oo8iyCmXOQuCiIvkPCM39o8FjsfbBOW6v9/hOtjbcO+x16fEQTyOyrtHM4b/xOVcrioxbVNny1P7Y2cpAj2njuKCsBm+la7PrOZvhG2CMJq14+I3upeJXdomynsn9cf+QInZr1BHLXdFAzk1CJoUZIRVQ1zVdyz+YqZXCu76iC5cKKUaoEDbjU4MT4CxWo85zHmOJ/8Xbyiyg7g8HKuG7Z6VuB0xUEXsen7k7iN3tX9IxkSQ3+V6VGyBJB7CSIRcCdmgpMv+FiNgnP9jRc9sNLB8gmqY2yowma2LjKF8byaEtC68J+M6uliYsPa7ScAbdhuhM/QW5ZxhwosgD6VvL+enCgd71rhqEqavYCoI5NMZkE29+sqffiAb+h+hYhAQNyP6eamlxkfaVJ3CUvP0N+RqAva+zbMqt3ortdgEIwh1N5A3gRN7LaklX1X7/cACtxHU2ZnuWydFnvZEZs7mjy62LKLw8MiiEG70S9AhOkXr7D+ebsZJeYVazmadW/A10kA56m2Xzt0tmnrmSClW1N+ubW1soLptUqViTjMTpfH7rxs7dKz3U+wqnzIUq0l8JnOjGUHV2mxY6xy0qrgrS63XEYH2EsY5nc3T3pnXyRkEJN5DOpiKjV/fcVpawcdVUj5cYT9Mo0fnr8PokBwEu+LKZM2eEBu4S16RV4gSk+SOuDsSutmUKL9o3uPzgbC8OxcZA/FxiZh4YBTkGz2HYc+MkmDkw9MWlFks0b+cK+6lt4bGTvxjhijdG9+mEPzdd+fH14LcR6fa+vFB+OWhnmx4G0pGMAbrFd1w3x12DDPcQHHyPwwPPdIHcjURAyL0gzbXogSkNipBjjFXha9Xu8V/WOJ4uLdRKK6cM5uC3cNRw1a+0U33zBM0DVGzURjZrOkPFM7FgDYpm1RgkJBrYPVNUvr531f9k31RGLa0LSd3q1NiWI05yzat0DhN83nebr6kN60H8cP3CSZhPgFPbxwm+xPreASkEnJX6Hszx1WOBzJHN70/LXccgHdI8pwV+ronAKDSfrCYd3YBXBMGFI/wxp1wJFxcQZpqb0jiBWZ/bXcKP7SZQeobxHMAhaz4rKSQMo9O7iWQ3AH/gnx4XvdmxpO4Uo5v7ycKHPSI5vG4zKIEUDSRKP7iHJ4p11tc9LLPlnNj9up36DqelCZ3nSyq+Ubvuv7ZchlAkwzbCA77wEyuvEGYl9/N7YeLUdhyiMxZm1ZQvTpxSy88dEqRV6GP0mE9gz1Hkh1clpBCrwy/lxx3ZnKYkBX/70bZxYKUlp6jfD0X0dFOTtp/vevgcflwLXU4VnR+uY6poszekP2iJ6etmX9lmH30j8N1g5NLQEZdCnTsHSfK/0eUgaEjmjb51tnx7aaN08zgT/sg2AYohdBFpKkEx7sF50EkeAZbjNbmPlHc5YehOlk0guGjK5dqpk6WARuK+sFhd/aF2Y7SD98aC6xJoAs5Z8+wslT8vDcG24jklxYmxMQMX+ld0h4Fgt8INMaTqgNQsmhfGiIRLiWzQtD/ETL3ZgtNTU4QtrYtrCu7vXyVVDmjImderNpiwAOWAMAiGSofRSgVvs2/xMjo83BrCjBDPQqVV8VdAILwPj/ZxJym4EKFwH5FxDS/Nb60awpWqAm3fk5K5A28LyjjKFR8t3vxi1VlNvyfOXeH5btlkE4e12gRVzAEbn5dGDeNsgvZi7WA2tHMUI3tUGSTniF+zFDo6+jiPxLm1At8BYd6J9E7G9kzbht94ON5H7wLj0WeAaFwTeo7f4/q69BXoYe5Xq+wRkFEErZ2iPVcglZoWO4hms9oxl2dbtnfImawW+6DMUVnQ5VeF7LI680vbMMZjNnCVsOUucAcQt8vxrvpHYT/1LqoTi9a9kOAiJSTE8zUIWPGhoQe/bxZrhyBo+Zda1Toq5MoLLpe9QsTUc6/ztdVx6O41HotS5NxZuUy8oF6DW/HPqrkfOgv+3WeShF8yDSnWnCpf6F6M15LdGFgjJiaajvah6XDIJ83H3UmnETLjy8syZ1sxULaORA4/sERpBr4ZZJSfYhCsxlWhOZ+Pf+0LYIDOy4KmY90nCImLe37+z1uob6FIU71GZlO4UW5yywxfJHESz6LXq5EvVghomT8eztF1kMfWWfbKLFFaJC72KOoZC9RW5kw/vvYNGlK36EuKLRTflIuSj+csEOuFalbdKjfyS+ZHgs2tviLTeFVlwcdXmDD42GbVZGlg0qP5nuOoKY9ME1KOOdy94du+egX1bJezEwvpQj7KI1GXaa0YAta2b2vWvbIc1gYLoATWmXk5XH7XJOHe6eZtJtVNSw+uKAs7Gxvn0dZAGWkC9N+AsCexOxIVOZ4=,iv:nTnYyHNq3zoR+mlCHfF4UbwJtgnfRRwjX7YLHA+FxUs=,tag:N43O7cyygK4nkt0ApvOarA==,type:str]
+    private_key: ENC[AES256_GCM,data:XYf+GyQdN1XmKBng3AwvKEsY/xQnQwMLDa/M17aiIt1NcTW7ENmt/TtKy45HdSLEnG1jFY//h4NNqgoVWNkLz0Sb82srfwebiCskq6VXeYp5An6XEVNJI5i/m8s8cG/Jtv4ZzXOM1kLCmkRce5AV6mIFJ4UO4vYhP06NTSpJWLCotQTi5OZc1TYZ/JqKTPuP7TZ003KclfjfJxQbPf1zqtiDfZObGNh+sd33uuxVt1rTP8OV2XSj6yToh6j7y9VvAUey264zGM0zn1BhuADXLRpdze69UKMbdKXP51v2MZrZtabgtr7HbibdN/HOslAAmDO42g9/QboiLucKl6p0oV42/qUDPqI++qGXr8iUO3fTnLf7rIIJFwP3SfNKB76E53UoxsXEwhqsM2mFFzId6kbNTd6gCq3AMz9vyMgGYkuDw30J3U8dsFqeLg5/8c2Bz3EPpSR17KPFdRGXuS7hbACV0ejjewheuqKHUike7KuNEz9BIb6bigdn2ROzYtF4kzP7Okm51+z+lmt+5IdfexKI97Bst4YxfMN6bFAy3CHSvPI7GX0N7LJ/hglT/Z3oNyMEVz4+VThM0yOI27+KUubDd5KtqH0BHfjnCgzWY601s9XXHquH59QBq0VM656F3EYFN0BRQ6RUrgSkga1sFB32HKlNbB4xMQ0eyS6IjQE1ecXLadoMAZYxJmKRY6/6L2oXh2BHi13gB433pb0z5xlLke4nws1Mn3fNETg1BLxYxD+XcS86W/QDxRjiY8y7TSSujJ2weeGxgz7JC2QhnTVKl4053oyzjPB95tJfAzHQlUD14f/hXOIrh8YArwticW6qr2/2Q2wcmZ1sS5WDmedN0axBFHmYPnmDI0VzmPSB5Knf9CrLOk2lZZ9/aj7I/moR35p2HCU99jPhpEKsPKjJQlecd5Jg6E0JWuUCj07itvWc5VxUzq6Qh4bQ7EBNFvcUng8bFW2iUnYlQOY1KJFNn2bAmZeRUbo+3oBynxSNMYfYXrO7DNSAVr2CS76tT8Pn4O4SLXSyM4lztxv5LniyG6ZzNetfDItC0+ZkuqFuqdZ+phRgugZknjvklrNrbDnQEmSropJq44WBR1khxnawQa15Nahw+LXZslQA34LdXIXoh1hWI/uH+z88b4ARfdmTnmtoZsbEbkBEkBvq4bhfy6sS5xT8ttOkqEFaTfnotRzHvlf1ysnnq1HXz7KK3snMCoC+YOh29eGy/x9QcxRxyUyB1LtRAI+8LCM98rrgmBfH2V+cemRUWK80uLxbHyUTOnEXq+1VNW9Zh2uHyZmC6h3RpuTq1d47p77a7JnazxqwegnDAFYzQzGhNQsNwgTeIeafAHeVMdQDo0n3uA7CRJbMqem11aIBWBo7X8PjKNGv6vDEonUKDiyI2Id6P55gbodahWWVusdqGhGEOhXM0eAFOFFEaylT93m+i/aixWTb4fP52smdpmGBjEvsw1ziZQk26yDzaeF/+Lpb27pta6HGj4qJu0I72BGV39x5begKfubQr8MY+cd2Wtdcw4R+oIpGQRykAkyMXkdAAgpgxAO8UqLBq0LxNeji2O4DdDBK2RcYP8uRcLSvo4l/5ABqkhJseXeNa3daYGr+SGY1qtFkb6yGKTVCYleVCoQRt9KzJTLSrt5b5JLH864IpawLY803PV3Rd8MmmO2KMObJO7ueUEaqDrwqgUjdd+R6S36M4F0U5fGECu31dw+TMsOSQgpCYTmFKdawgroslW/Ksh+2z3w7t5G73dIUnjGcgsH/pB0ULoz2WVxnf7x58Y6KPfmMUYGLNtki3nVKj3PDLUd2QgnKvFYoqlWfP9ofvDMTMn7z8aVQH68rhxkKzF+owEAMlOezXamx+W20WW4DKeNomGdDfxKtI+teBztypC4D+SrNItDAnYxTaOAvzILRh4iZefBKPHPvO39JAjSsPkL6ZvJeE0HnwU4RP0tlzBQLeHNNt73tHQI8ri3uQlMtRqBLIBteplqxSXaD1SW46a+xgqtYDc57I/tXSGcmbY2hDWEO97hMLoQC/LHK/kUjEiFj/gpOh95AdL86SARCVfMmTtMh01q0cnI0etdGxkDRKcnup0bGEkINXDzCsVrOjna1EDn3sDewdmGWkfRLkOjth+fkINKFoUFyBg9LOSFPBAqYXJ0y3yQaRiB2VJnz1K1uxV72t7mg+SrmLnsa7UAbky56PXzYE14oAqxPDAiExAbCCAU7TQG8UC/SDYz2hIKRuiRy+9QNpj2rKdCIXfAhunsFEEZfVzQqynBwkVS7KpaehEzUR+WYaKA6y2VxxoBVaPgunKiHLi8oCpaFlmgZf4rgFp44Z3XQEJ+9/AOz3mt1ZOgcWuWcYOol6pJ5lwVsBl+ufMywXX8Fb41EEW8i1sPvqML9HA0bxm7C1GwtoWrCXiTzIQwZHS4gD2aJoZty2PLlO2qLHDqDENCIFxhTRzYeDKWobqEtSYDo4jndWKXIa6owHGq0VCmUD4YLKzObikBpMdu0O9CPRA9Tjjo=,iv:jd3LATRmBUo0LN1J10qUjKtQW6y2Xil9Lflrt3vhbXs=,tag:DXUpwF8i9fWX13HvmOyqpA==,type:str]
 sops:
-    lastmodified: "2026-05-30T22:10:16Z"
-    mac: ENC[AES256_GCM,data:FGbcCyRidC62dGW5W7lZHkSXFaA2KJ63Z8FtCHlN5fymantsDJoqhoBGNvgeuO82++Q6cpB8TxzmWIVBRiJzP63V4xj2hQSldmDidOp9jMa7hhVYGW4aAj9AQstgSZ6k8EGcl4qXr54hNx1xfAGdHP7w9++d918RpTFOcpUnqN4=,iv:C32oDudwsKRLJnfEV5AhHJbtvWZUCsD+121vFAGXkGk=,tag:N0X8qIkU5IuFHQeu+ZatKw==,type:str]
+    lastmodified: "2026-08-07T13:26:58Z"
+    mac: ENC[AES256_GCM,data:sQ00rQCZA4C6noBe4caVaSKOpldS0RIhEVxjKDkpJq4MEIVMRqR7hvfAJYz1zEpegUjGV3Gk1YXzfC+uYL2rBfA+Zh/Tjox1hbZELxt+/f9qNdN5nuxtUZE5lBM1zYzMD8jXr+DYC20+AKZKZBJ+gTf0ulJPqucrXE+4/ctEurk=,iv:9kCt5szD5G5CSruLgt5HIGnb4Xz1jd0J6KBy6UBUA4Q=,tag:4wHoUyl4YppZzl23luguxA==,type:str]
     pgp:
-        - created_at: "2026-05-30T22:10:16Z"
+        - created_at: "2026-08-07T13:26:58Z"
           enc: |-
             -----BEGIN PGP MESSAGE-----
 
-            hF4DYhYgzaKQYR0SAQdAjifE75qu3SnOiwKRhKBaOKp0JTYPc6fj0zELLi5clV0w
-            6YJp6p65e/hC0SlnmKGMjtKFq7l9BMBjbMPqq0L/4A8VQLdwliWP4TIrK5VcByTW
-            1GYBCQIQBhSxh+uGgSOAsOPpAWn++0nB6mH84aDwT3S1Qru6m1D7TC1nkhDlnYPm
-            jhSJek+5SVPjxSSstDk7FWZWqKKYoidrQFHWAQ2C7gdtsxAU4uG1yQYiXLhklFKy
-            lILIRKT9izk=
-            =02FH
+            hF4DYhYgzaKQYR0SAQdAihzxV1b2b036tdupJlgqKj5h7liPp3hXnBvRsuAbi3Qw
+            GPJiC3nC1mxAMYccTP2MxvYbSvyjKMvo1bi2qE9W6YXTGnck3YXjNVWNZvxGLvF7
+            1GgBCQIQ7Zr+l66GbkuFgSKm4U3iDvs7qB/l09iBWT4OoB/B43d35n3wRL5lNIXU
+            ES0xMuOe0Ng3uWgHp6ZyH1g3nv7VOyORptqyXWMoaxrFAe0bZ0BES192DDPBjNLy
+            dNzkXZ4dppeYlQ==
+            =sAR4
             -----END PGP MESSAGE-----
           fp: 905EBD494A6AA2B774ED5C67621620CDA290611D!
-        - created_at: "2026-05-30T22:10:16Z"
+        - created_at: "2026-08-07T13:26:58Z"
           enc: |-
             -----BEGIN PGP MESSAGE-----
 
-            hF4DiMEcS0DKCgcSAQdAL9NaKjailDVtiL0X0EWax/4dfe7Dh1yB1M4+1N7cxCEw
-            cFFCFwM+IPbOddoAFxXJ9eM9I5Hy+dYLNGDH4E/izaw3cRQQ0i4fOdCtMU8Kr/Cu
-            1GYBCQIQcTLSxLutSHmCgsGNnfCSXdFnBeRGwgv+Bs0RO1AUmsCH35mQx+QsXt0r
-            jPpW1IVpaO3KqdotCMhqq/g9/ApbM0WvFtjKMuVfurridNNob5nkoOiyEW/lpGRQ
-            KWrZOFS5Xr8=
-            =nsk3
+            hF4DiMEcS0DKCgcSAQdA4pZVejSqaHOiurKUKQi/0g02TWRLyvQaR75lmfopkhYw
+            YgLXNYKhX7LNK+7JwNWNM2lCuF5mL3GyOswRErCNiqXv0i+rt++hc7KwWebFXx9a
+            1GgBCQIQeMFdW+xU3elS1bIQr1eTFSWHHK3ObRoKSxN89JzXkit+RQChgihx+ZvG
+            d7B2wB8LuO59SxrpLRS5hgJsLavJ9TxooqyTWDkCqCDXJzmdE+YyT+FtO8PHcOKH
+            OJP9oGzzx2Y2Tg==
+            =snWg
             -----END PGP MESSAGE-----
           fp: 29451B3218DDD551B34905DF88C11C4B40CA0A07!
-        - created_at: "2026-05-30T22:10:16Z"
+        - created_at: "2026-08-07T13:26:58Z"
           enc: |-
             -----BEGIN PGP MESSAGE-----
 
-            hF4DSKZOgzO4L1ASAQdA3tq5V4fUMektLVNtsXJISEC3bEzvOgtMfpj2bhMjzj4w
-            2//AzpITvLgxHQ+NUeTkujbYoPG2ZsVPtatCHm5OJpSIjJe+8icj4asOcWODvt7m
-            1GYBCQIQ5tlhYojbChW9Tg9mnwt5IcMA7ZCJPn4IDKkXCYcIgcNOGlOJTSPgLCkJ
-            o/QGJgAGhEMijHwr6iut+cT1TkZBfysbmduBbt7tQymrB0mMfVxce3ifAADyKXXf
-            ZNPimYMcXgw=
-            =O/7w
+            hF4DSKZOgzO4L1ASAQdA8LCBWr9+Y2ukgKe+CuswAtnpVDeG+PfgTF8OunmXFiIw
+            3QbTMQfHIeBVwgKPZx1RmCLp/kDQeaJamAW1xvwSTAp9VJvhPY+1YvdLwl7JhCWz
+            1GgBCQIQ/QIWTIVqm1v3ckENkXn/OJ19TvtmIbaVObn3twNJUiLq/JM100ZCeqf8
+            Vp455xKo8AcPJRljO0d0JQA2+E9n+3L7PPhOetNTY+P6OHkDjakVlexmZfixkJ3Q
+            55nszEt6ZYwS1Q==
+            =AQ4H
             -----END PGP MESSAGE-----
           fp: A2164C4257BB2EBFA51F26E948A64E8333B82F50!
     unencrypted_suffix: _unencrypted
-    version: 3.12.1
+    version: 3.13.3


### PR DESCRIPTION
TL;DR
-----
Adds AI-assisted editing inside Neovim via [Avante.nvim](https://github.com/yetone/avante.nvim), using Moonshot's Kimi K2.7 coding model served through OpenRouter. Complements the existing OpenCode workflow rather than replacing it.

Details
-------
The `ai` home-manager module now installs `avante-nvim` along with its dependencies (`nui-nvim`, `render-markdown-nvim`, `img-clip-nvim`) and configures it through `extraLuaConfig`:

- **Provider**: OpenRouter's OpenAI-compatible endpoint with `moonshotai/kimi-k2.7-code` (262k context), via Avante's `__inherited_from = "openai"` vendor pattern.
- **Editor integration**: snacks.nvim for input, fzf for file selection, right-hand sidebar — all reusing plugins the editor module already ships.
- **No conflicts**: auto-suggestions stay off so Avante doesn't fight supermaven-nvim for completions.

The API key comes from a new sops-managed secret (`openrouter/apiKey`) exported as `OPENROUTER_API_KEY` in both zsh and fish, following the same pattern as the OpenCode secrets. The secret has been added to `home/users/crdant/secrets.yaml`.

The integration plan is included at `docs/plans/2026-05-11-003-feat-avante-nvim-integration-plan.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)