### PR TITLE
Make the obsidian module safe for NixOS hosts

### DIFF
--- a/systems/modules/obsidian/default.nix
+++ b/systems/modules/obsidian/default.nix
@@ -1,23 +1,27 @@
-{ pkgs, lib, ... }:
+{ pkgs, lib, options, ... }:
 
 let
-  isDarwin = pkgs.stdenv.isDarwin;
-in {
-  homebrew = lib.mkIf isDarwin {
-    casks = [
-      "obsidian"
-    ];
-    masApps = {
-      "Obsidian Web Clipper" = 6720708363;
+  supportsHomebrew = builtins.hasAttr "homebrew" options;
+  homebrewConfig = lib.optionalAttrs supportsHomebrew {
+    homebrew = {
+      casks = [
+        "obsidian"
+      ];
+      masApps = {
+        "Obsidian Web Clipper" = 6720708363;
+      };
     };
   };
-
-  users.groups = {
-    obsidian = {
-      # Read/write access to obsidian vaults
+in (lib.mkMerge [
+  homebrewConfig
+  {
+    users.groups = {
+      obsidian = {
+        # Read/write access to obsidian vaults
+      };
+      obsidian-readonly = {
+        # Read-only access to obsidian vaults
+      };
     };
-    obsidian-readonly = {
-      # Read-only access to obsidian vaults
-    };
-  };
-}
+  }
+])


### PR DESCRIPTION
TL;DR
-----

Makes the system-level obsidian module evaluable on NixOS hosts, so the workstation role no longer fails on the first NixOS machine to use it (sochu, as part of its dual-boot rebuild).

Details
-------

Replaces the module's `lib.mkIf isDarwin` guard around its homebrew block. `mkIf` only guards an option's *value* — the module system still requires the `homebrew` option to be declared before accepting the definition, and NixOS doesn't declare it, so any NixOS host importing the module failed evaluation with `The option 'homebrew' does not exist`. Nothing tripped this before because the only NixOS host (mash) uses the jumpbox role, which skips obsidian.

Follows the guard pattern the development, desktop, and essential-packages modules already use: detect the option with `builtins.hasAttr "homebrew" options`, omit the `homebrew` attribute entirely via `lib.optionalAttrs` when it isn't declared, and return the module through `lib.mkMerge` so its attribute shape doesn't depend on `options` (a plain `//` merge recurses infinitely).

Changes no obsidian behavior: same cask, same Obsidian Web Clipper MAS app, same `obsidian`/`obsidian-readonly` groups. Verified that `darwinConfigurations.aguardiente` still resolves the obsidian cask on this branch and that `nixosConfigurations.sochu` on the dual-boot branch evaluates with both groups present.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
