### PR TITLE
Restore fish man-page completion generation

### DIFF
--- a/home/modules/base/fish.nix
+++ b/home/modules/base/fish.nix
@@ -7,11 +7,6 @@ in {
   programs.fish = {
     enable = true;
 
-    # fish 4.8+ dropped share/fish/tools/create_manpage_completions.py, which
-    # Home Manager's man-page completion generator invokes; disable it so the
-    # build doesn't fail. Built-in and package-vendored completions still work.
-    generateCompletions = false;
-
     shellAliases = {
       more = "less -X";
       pd = "pushd";

--- a/overlays/default.nix
+++ b/overlays/default.nix
@@ -36,7 +36,21 @@
 
     direnv = final.unstable.direnv;
 
-    fish = final.unstable.fish;
+    # fish 4.8 stopped installing share/fish/tools — everything but man pages
+    # now lives inside the binary, retrievable with `status get-file`. The
+    # NixOS and Home Manager 26.05 fish modules still read the man-page
+    # completion generator from the old path, so extract it and put it back.
+    # Drop once the release branches pick up the `status get-file` module
+    # fixes that are already on master (home-manager PR #9555, nixpkgs
+    # PR #534907).
+    fish = final.unstable.fish.overrideAttrs (oldAttrs: {
+      postInstall = (oldAttrs.postInstall or "") + ''
+        mkdir -p $out/share/fish/tools
+        HOME=$(mktemp -d) $out/bin/fish --no-config \
+          -c 'status get-file tools/create_manpage_completions.py' \
+          > $out/share/fish/tools/create_manpage_completions.py
+      '';
+    });
 
     mas = final.unstable.mas;
 


### PR DESCRIPTION
TL;DR
-----

Brings back fish's man-page-derived completions on every host by re-adding the completion generator script that fish 4.8 stopped installing, and reverts July's `generateCompletions = false` workaround (#306) that made for a noticeably worse fish experience.

Details
-------

Extracts `create_manpage_completions.py` from the fish binary in the overlay's `postInstall` and puts it back at `share/fish/tools/`, where the NixOS and Home Manager fish modules still expect it. fish 4.8 stopped installing anything under `share/fish/` except man pages — the tools are embedded in the binary, retrievable with `status get-file`. Both upstream module fixes for this are master-only: home-manager PR [#9555](https://github.com/nix-community/home-manager/pull/9555) was never backported to release-26.05, and nixpkgs stable took fish 4.8.1 without the module change ([#534907](https://github.com/NixOS/nixpkgs/pull/534907)) that shipped beside it on master. Restoring the file on disk fixes both modules without touching either; the overlay comment marks it as droppable once the release branches catch up.

Accepts one tradeoff knowingly: `overrideAttrs` changes fish's derivation hash, so every machine compiles fish from source (it's a Rust build) — again on each future unstable bump — until the overlay comes out. The zero-rebuild alternative (`disabledModules` plus vendored copies of both fixed modules) was more moving parts than the recurring compile is worth.

Verified end to end on aarch64-darwin: the overlaid fish builds with the script restored, Home Manager's `fish_patched-completion-generator` unpacks and patches it successfully, and the `crdant-fish-completions` output generates 685 completion files from installed man pages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)