### PR TITLE
Make the console legible on Retina panels

### DIFF
--- a/docs/hidpi.md
+++ b/docs/hidpi.md
@@ -1,0 +1,51 @@
+# HiDPI support
+
+Support for high-density panels (Retina laptops, ~2x displays) on NixOS
+hosts. Two opt-in modules, neither wired into any role:
+
+- `systems/modules/hidpi` — system level. Enables `console.earlySetup` with a
+  32px Terminus font (`ter-v32n`) so the virtual console — including the LUKS
+  passphrase prompt in the initrd — is legible, and sets
+  `boot.loader.systemd-boot.consoleMode = "auto"` so the boot menu doesn't
+  render at tiny native resolution. Darwin-safe via the usual `options` guard,
+  though only NixOS hosts have any reason to import it.
+- `home/modules/desktop/hidpi.nix` — home level, GNOME dconf tuning. Currently
+  all commented out, deliberately: see below.
+
+## What the desktop environment handles itself
+
+Wayland compositors own display scaling at runtime. On a ~254 ppi panel
+mutter picks 200% automatically and persists the choice per-monitor in
+`~/.config/monitors.xml`; COSMIC does its own equivalent. At clean integer
+scaling nothing needs to be set declaratively, which is why the home module
+ships empty. Do not add X11-era DPI settings, global `GDK_SCALE`-style
+environment variables, or xrandr machinery — they fight the compositor.
+
+The home module keeps two knobs commented for when integer scaling isn't
+right:
+
+- `text-scaling-factor` — scales text only, on top of the monitor scale. The
+  cheap way to get "slightly smaller than 2x" without fractional scaling.
+- `org/gnome/mutter` `experimental-features` — fractional monitor scaling
+  (`scale-monitor-framebuffer`) is still experimental in the GNOME shipped
+  with nixpkgs 26.05.
+
+## XWayland blurriness under fractional scaling
+
+XWayland clients can't render at fractional scales, so under fractional
+scaling mutter scales their buffers up and they look blurry. GNOME's
+`xwayland-native-scaling` experimental feature (paired with
+`scale-monitor-framebuffer`) has XWayland apps render at the ceiling integer
+scale and downscales, which sharpens well-behaved apps but can shrink UI in
+apps that ignore the advertised X11 DPI. Integer scaling avoids the whole
+problem — prefer it when the panel allows.
+
+## Opting a host in
+
+```nix
+# systems/hosts/<host>/default.nix
+imports = [ ../../modules/hidpi ];
+
+# the host's home-manager configuration
+imports = [ ../../modules/desktop/hidpi.nix ];  # adjust path as needed
+```

--- a/home/modules/desktop/hidpi.nix
+++ b/home/modules/desktop/hidpi.nix
@@ -1,0 +1,32 @@
+# GNOME HiDPI settings for a Retina laptop. Not imported anywhere yet: a
+# host's home configuration (or a later merge) wires it in alongside the
+# desktop module.
+#
+# The default stance is clean 200% integer scaling, which mutter selects
+# automatically on a ~254 ppi panel and persists per-monitor in
+# ~/.config/monitors.xml — no dconf keys required. Everything below is
+# therefore opt-in tuning, left commented until a real display asks for it.
+{ ... }:
+
+{
+  dconf.settings = {
+    # "org/gnome/desktop/interface" = {
+    #   # Scales text only, on top of the monitor scale. Use for in-between
+    #   # sizes (e.g. 2x monitor scale feels big, so 2x * 0.9 text) instead
+    #   # of reaching for fractional monitor scaling.
+    #   text-scaling-factor = 0.9;
+    # };
+
+    # "org/gnome/mutter" = {
+    #   # Fractional monitor scaling (125%/150%/175% in Display settings) is
+    #   # still experimental in the GNOME shipped with nixpkgs 26.05 and
+    #   # hidden behind this flag. It also renders XWayland apps blurry
+    #   # (scaled up from a smaller buffer) unless xwayland-native-scaling
+    #   # is enabled too — see docs/hidpi.md.
+    #   experimental-features = [
+    #     "scale-monitor-framebuffer"
+    #     "xwayland-native-scaling"
+    #   ];
+    # };
+  };
+}

--- a/systems/hosts/sochu/nixos.nix
+++ b/systems/hosts/sochu/nixos.nix
@@ -2,6 +2,7 @@
 {
   imports = [
     ./hardware-configuration.nix
+    ../../modules/hidpi
     inputs.nixos-apple-silicon.nixosModules.apple-silicon-support
   ];
 

--- a/systems/modules/hidpi/default.nix
+++ b/systems/modules/hidpi/default.nix
@@ -1,0 +1,28 @@
+# HiDPI support for NixOS hosts with high-density panels (e.g. Retina
+# laptops). Hosts opt in by importing this module directly; it is not part
+# of any role. Wayland desktops (GNOME, COSMIC) handle display scaling at
+# runtime, so this only covers what they can't: the early console and the
+# boot menu.
+{ pkgs, lib, options, ... }:
+
+let
+  # console/boot.loader only exist on NixOS; guard so the module stays
+  # darwin-safe if a role ever pulls it in.
+  supportsConsole = builtins.hasAttr "console" options;
+  consoleConfig = lib.optionalAttrs supportsConsole {
+    console = {
+      # Load the font from the initrd so the LUKS passphrase prompt is
+      # legible, not just the post-boot VTs.
+      earlySetup = true;
+      font = "${pkgs.terminus_font}/share/consolefonts/ter-v32n.psf.gz";
+      packages = [ pkgs.terminus_font ];
+    };
+
+    # "keep" (the default) leaves the firmware's native-resolution mode,
+    # which renders the boot menu tiny on a Retina panel; let systemd-boot
+    # pick a readable mode instead. Harmless on hosts using another loader.
+    boot.loader.systemd-boot.consoleMode = lib.mkDefault "auto";
+  };
+in (lib.mkMerge [
+  consoleConfig
+])


### PR DESCRIPTION
TL;DR
-----

Adds an opt-in HiDPI module so high-density panels get a readable virtual console — including the LUKS passphrase prompt — and a boot menu that isn't rendered at microscopic native resolution, then opts sochu in.

Details
-------

Adds `systems/modules/hidpi`, opt-in per host rather than part of any role: `console.earlySetup` with a 32px Terminus font (`ter-v32n`, chosen for glyph coverage; loaded from the initrd so the LUKS prompt benefits, not just post-boot VTs) and `boot.loader.systemd-boot.consoleMode = "auto"` under `mkDefault`. Darwin-safe via the usual `builtins.hasAttr` guard.

Adds `home/modules/desktop/hidpi.nix`, deliberately inert: Wayland compositors own display scaling at runtime (mutter picks and persists 200% on its own), so nothing is declared — the fractional-scaling and text-scaling knobs sit commented with explanations for when integer scaling isn't right, activating alongside the desktop-environment branch. `docs/hidpi.md` explains the split and the XWayland caveat.

These files were meant to ride into main inside the dual-boot PR (#322) via cherry-pick, but the squash merge and the cherry-pick push crossed in flight — the merge captured the branch one commit early. This PR restores the two missing commits on their original branch, rebased onto the merged main.

Verification: `nixosConfigurations.sochu` evaluates with `console.earlySetup = true` and the Terminus font path; darwin configurations unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)