### PR TITLE
Name sochu's NixOS side

### DIFF
--- a/systems/hosts/sochu/nixos.nix
+++ b/systems/hosts/sochu/nixos.nix
@@ -7,6 +7,8 @@
 
   hardware.asahi.enable = true;
 
+  networking.hostName = "sochu";
+
   # Wi-Fi-only laptop: NetworkManager instead of the networkd stack that
   # system-defaults/home-lab push for servers (mkForce because they set it
   # at normal priority)


### PR DESCRIPTION
TL;DR
-----

Sets `networking.hostName = "sochu"` — the NixOS side has been running as the distribution-default `nixos`, which breaks `make host` on the machine itself.

Details
-------

The Makefile dispatches host targets on `hostname -s`, so the machine currently looks for a configuration named `nixos` and reports none found; explicit `--flake .#sochu` invocations masked the gap during bring-up. Every other host declares its name in its host module — sochu's `nixos.nix` simply never did. Spotted from the `crdant@nixos` shell prompt while trying to reach the machine over the network (it also advertises the wrong name everywhere DHCP or mDNS would use it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)