### PR TITLE
Rename resolved options to settings.Resolve paths

### DIFF
--- a/systems/modules/system-defaults/default.nix
+++ b/systems/modules/system-defaults/default.nix
@@ -169,8 +169,10 @@ let
   resolvedConfig = lib.optionalAttrs supportsResolved {
     services.resolved = {
       enable = true;
-      dnssec = "allow-downgrade";
-      dnsovertls = "opportunistic";
+      settings.Resolve = {
+        DNSSEC = "allow-downgrade";
+        DNSOverTLS = "opportunistic";
+      };
     };
   };
 


### PR DESCRIPTION
TL;DR
-----

Silences the `services.resolved.dnssec`/`dnsovertls` rename warnings that every `nixos-rebuild switch` on sochu emits, with no change to the rendered resolved.conf.

Details
-------

Moves the two options in systems/modules/system-defaults to their new nixpkgs 26.05 homes, `services.resolved.settings.Resolve.DNSSEC` and `services.resolved.settings.Resolve.DNSOverTLS`. The new `settings.Resolve` section is freeform (systemd `unitOption`), so the existing string values "allow-downgrade" and "opportunistic" carry over verbatim; evaluating `services.resolved.settings.Resolve` on mash confirms they land unchanged. Getting off the aliases now avoids breakage when nixpkgs drops them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)