### PR TITLE
Refresh macOS desktop apps and correct git identity

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -81,11 +81,11 @@
     },
     "nixpkgs-unstable": {
       "locked": {
-        "lastModified": 1785301185,
-        "narHash": "sha256-eoS3KQTO0aPWXZvIaRbRAzSSHW3l5wdMFXtT1ISfoKA=",
+        "lastModified": 1785747939,
+        "narHash": "sha256-D740uKsMbgsfK2oaDenJLLPIZfq7W0/g4KN/Fls8eKs=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "9bc02893134c733dd85de46ee4fb2fac696b5529",
+        "rev": "104240a772428cc2e20d8fd86c9ddbb886bbaff2",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -108,7 +108,7 @@
               homeModule = ./home/users/crdant/home.nix;
             };
             crdant = {
-              gitEmail = "chuck@crdant.io";
+              gitEmail = "crdant@shortrib.io";
             };
             luca = {
               gitEmail = "";

--- a/systems/modules/desktop/default.nix
+++ b/systems/modules/desktop/default.nix
@@ -15,6 +15,7 @@ let
       };
       
       casks = [
+        "apparency"
         "displaybuddy"
         "font-cabin"
         "font-noto-sans"
@@ -24,8 +25,10 @@ let
         "noun-project"
         "popclip"
         "proxyman"
-        "quicklook-json"
+        "qlmarkdown"
+        "quickjson"
         "rancher"
+        "suspicious-package"
         "tailscale-app"
       ];
 

--- a/systems/modules/desktop/default.nix
+++ b/systems/modules/desktop/default.nix
@@ -33,7 +33,6 @@ let
       ];
 
       masApps = {
-       # "1Blocker" = 1365531024;
        "1Password for Safari" = 1569813296;
        "Amphetamine" = 937984704;
        "Ghostery Privacy Ad Blocker" = 6504861501;

--- a/systems/modules/desktop/default.nix
+++ b/systems/modules/desktop/default.nix
@@ -27,7 +27,6 @@ let
         "proxyman"
         "qlmarkdown"
         "quickjson"
-        "rancher"
         "suspicious-package"
         "tailscale-app"
       ];

--- a/systems/modules/desktop/default.nix
+++ b/systems/modules/desktop/default.nix
@@ -38,13 +38,13 @@ let
        "Ghostery Privacy Ad Blocker" = 6504861501;
        "iMovie" = 408981434;
        "Kagi for Safari" = 1622835804;
-       "Keynote" = 409183694;
+       "Keynote" = 361285480;
        "Microsoft Excel" = 462058435;
        "Microsoft PowerPoint" = 462062816;
        "Microsoft Remote Desktop" = 1295203466;
        "Microsoft Word" = 462054704;
-       "Numbers" = 409203825;
-       "Pages" = 409201541;
+       "Numbers" = 361304891;
+       "Pages" = 361309726;
        "Todoist" = 585829637;
        "Transmit" = 1436522307;
       };


### PR DESCRIPTION
TL;DR
-----

Routine refresh of the macOS desktop app set — swaps stale QuickLook extensions and Rancher Desktop for maintained alternatives — and corrects crdant's default git email to the shortrib.io address.

Details
-------

Replaces the abandoned `quicklook-json` cask with `quickjson` and adds `qlmarkdown`, `apparency`, and `suspicious-package` to modernize QuickLook coverage for JSON, Markdown, apps, and installer packages.

Removes the Rancher Desktop cask; container workloads already run through Colima, which the containers home module installs from unstable.

Updates the Mac App Store IDs for Keynote, Numbers, and Pages to the current listings and drops the commented-out 1Blocker entry that Ghostery replaced.

Corrects the `gitEmail` for user crdant from `chuck@crdant.io` to `crdant@shortrib.io` and bumps `nixpkgs-unstable` in the flake lock as part of the refresh.

🤖 Generated with [Claude Code](https://claude.com/claude-code)